### PR TITLE
Cmake Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
 
-add_compile_options(NuOscillator_Compiler_Flags)
+add_compile_options(${NuOscillator_Compiler_Flags})
 
 #================================================================================================
 #Setup Deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
 endif()
 
 if(NOT DEFINED UseGPU)
-       message(FATAL_ERROR "${UseGPU} not defined")
+       message(FATAL_ERROR "UseGPU is not defined, add -DUseGPU=<1/0>")
 endif()
 
 SET(NUOSCILLATOR_VERSION 0.0)
 
-if(${UseGPU} EQUAL 1)
+if(${UseGPU} EQUAL 0)
 	project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX)
 else()
 	project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX CUDA)
@@ -35,6 +35,7 @@ endif()
 
 #================================================================================================
 #Custom variable sanitisation
+add_library(NuOscillatorCompilerOptions INTERFACE)
 
 foreach(VAR UseGPU UseMultithreading UseDoubles UseCUDAProb3 UseCUDAProb3Linear UseProb3ppLinear UseProbGPULinear)
 	    if(NOT DEFINED ${VAR})
@@ -72,12 +73,8 @@ if(${UseCUDAProb3} EQUAL 1 AND ${UseCUDAProb3Linear} EQUAL 1)
 endif()
 
 if(${UseMultithreading} EQUAL 1)
-	find_package(OpenMP)
-	if (OPENMP_FOUND)
-	    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-	    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    	    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-	endif()
+  target_compile_options(NuOscillatorCompilerOptions INTERFACE -fopenmp)
+  target_link_libraries(NuOscillatorCompilerOptions INTERFACE gomp)
 endif()
 
 if(${UseGPU} EQUAL 1)
@@ -133,10 +130,10 @@ if(${UseCUDAProb3} EQUAL 1)
 		DOWNLOAD_ONLY
 	   )
 	   if(NOT CUDAProb3_ADDED)
-	   	  message(FATAL_ERROR "Could not download CUDAProb3")
+	   	  cmessage(FATAL_ERROR "Could not download CUDAProb3")
 	   endif()
 
-	   add_compile_definitions(UseCUDAProb3=1)
+	   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseCUDAProb3=1)
 endif()
 
 if(${UseCUDAProb3Linear} EQUAL 1)
@@ -156,10 +153,9 @@ if(${UseCUDAProb3Linear} EQUAL 1)
 			)
 	endif()
 	if(NOT TARGET CUDAProb3Beam OR NOT TARGET CUDAProb3Atmos)
-	       message(FATAL_ERROR "Could not find CUDAProb3Linear")
+	       cmessage(FATAL_ERROR "Could not find CUDAProb3Linear")
 	endif()
-
-	add_compile_definitions(UseCUDAProb3Linear=1)
+	target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseCUDAProb3Linear=1)
 endif()
 
 if(${UseGPU} EQUAL 1)
@@ -170,10 +166,10 @@ if(${UseGPU} EQUAL 1)
 			GITHUB_REPOSITORY dbarrow257/ProbGPU
 			)
 		   if(NOT TARGET ProbGPU)
-       	       	   	message(FATAL_ERROR "Could not find ProbGPU")
+			cmessage(FATAL_ERROR "Could not find ProbGPU")
 		   endif()
 
-		   add_compile_definitions(UseProbGPULinear=1)
+		target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseProbGPULinear=1)
 	endif()
 endif()
 
@@ -185,28 +181,28 @@ if(${UseProb3ppLinear} EQUAL 1)
         	GITHUB_REPOSITORY mach3-software/Prob3plusplus
 		)
 	   if(NOT TARGET Prob3plusplus)
-       	   	message(FATAL_ERROR "Could not find Prob3plusplus")
+       	   	cmessage(FATAL_ERROR "Could not find Prob3plusplus")
 	   endif()
-
-	   add_compile_definitions(UseProb3ppLinear=1)
+	   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseProb3ppLinear=1)
 endif()
 
 if(${UseGPU} EQUAL 1)
-	     add_compile_definitions(UseGPU=1)
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseGPU=1)
 else()
-	     add_compile_definitions(UseGPU=0)
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseGPU=0)
 endif()
 
 if(${UseMultithreading} EQUAL 1)
-             add_compile_definitions(UseMultithreading=1)
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseMultithreading=1)
 else()
-             add_compile_definitions(UseMultithreading=0)
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseMultithreading=0)
 endif()
 
 if(${UseDoubles} EQUAL 1)
-             add_compile_definitions(UseDoubles=1)
+    # Dan_Double
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseDoubles=1)
 else()
-             add_compile_definitions(UseDoubles=0)
+    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseDoubles=0)
 endif()
 
 #================================================================================================
@@ -230,12 +226,18 @@ install(FILES
 install(DIRECTORY Configs DESTINATION ${CMAKE_INSTALL_PREFIX}/)
 install(DIRECTORY Inputs DESTINATION ${CMAKE_INSTALL_PREFIX}/)
 
+
+set_target_properties(NuOscillatorCompilerOptions PROPERTIES EXPORT_NAME CompilerOptions)
+install(TARGETS NuOscillatorCompilerOptions
+    EXPORT NuOscillator-targets
+    LIBRARY DESTINATION lib/)
+
 #================================================================================================
 
 #This is to export the target properties of NuOscillator
 #Anything that links to "NuOscillator" will get all of these target properties
 add_library(NuOscillator INTERFACE)
-target_link_libraries(NuOscillator INTERFACE Oscillator::Oscillator OscProbCalcer::OscProbCalcer)
+target_link_libraries(NuOscillator INTERFACE Oscillator OscProbCalcer NuOscillatorCompilerOptions)
 set_target_properties(NuOscillator PROPERTIES EXPORT_NAME All)
 
 install(TARGETS NuOscillator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,18 @@ if(${UseGPU} EQUAL 1)
     			set(CMAKE_CUDA_ARCHITECTURES 35 52 60 61 70 75 80 86)
   		    endif()
 	     endif()
+
+    if(NOT DEFINED NuOscillator_Compiler_Flags_CUDA)
+        set(NuOscillator_Compiler_Flags_CUDA "")
+    endif()
+    add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:${NuOscillator_Compiler_Flags_CUDA}>)
 endif()
 
-if(NOT DEFINED)
+if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
 
 add_compile_options(NuOscillator_Compiler_Flags)
-
 
 #================================================================================================
 #Setup Deps
@@ -221,7 +225,6 @@ add_subdirectory(Oscillator)
 add_subdirectory(Apps)
 
 #================================================================================================
-#
 
 set(LIBDEST ${CMAKE_INSTALL_PREFIX}/lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ endif()
 if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
+message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
 
 string(REPLACE ";" " " NuOscillator_Compiler_Flags "${NuOscillator_Compiler_Flags}")
 separate_arguments(NuOscillator_Compiler_Flags)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ endif()
 #Custom variable sanitisation
 add_library(NuOscillatorCompilerOptions INTERFACE)
 
+message(STATUS "NuOscillator Features: ")
 foreach(VAR UseGPU UseMultithreading UseDoubles UseCUDAProb3 UseCUDAProb3Linear UseProb3ppLinear UseProbGPULinear)
 	    if(NOT DEFINED ${VAR})
 	    	   message(FATAL_ERROR "${VAR} not defined")
@@ -91,6 +92,13 @@ if(${UseGPU} EQUAL 1)
   		    endif()
 	     endif()
 endif()
+
+if(NOT DEFINED)
+    set(NuOscillator_Compiler_Flags "")
+endif()
+
+add_compile_options(NuOscillator_Compiler_Flags)
+
 
 #================================================================================================
 #Setup Deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,7 @@ endif()
 if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
-message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
 
-string(REPLACE ";" " " NuOscillator_Compiler_Flags "${NuOscillator_Compiler_Flags}")
 separate_arguments(NuOscillator_Compiler_Flags)
 
 message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
 
+separate_arguments(NuOscillator_Compiler_Flags)
+
 add_compile_options(${NuOscillator_Compiler_Flags})
 
 #================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ if(NOT DEFINED NuOscillator_Compiler_Flags)
 endif()
 
 separate_arguments(NuOscillator_Compiler_Flags)
-
+message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
 add_compile_options(${NuOscillator_Compiler_Flags})
 
 #================================================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ if(NOT DEFINED NuOscillator_Compiler_Flags)
     set(NuOscillator_Compiler_Flags "")
 endif()
 
+string(REPLACE ";" " " NuOscillator_Compiler_Flags "${NuOscillator_Compiler_Flags}")
 separate_arguments(NuOscillator_Compiler_Flags)
+
 message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
 add_compile_options(${NuOscillator_Compiler_Flags})
 

--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(OSCPROBCALCER_VERSION 0.0)
 set(HEADERS OscProbCalcerBase.h)
 
 add_library(OscProbCalcer SHARED OscProbCalcerBase.cpp)
-target_link_libraries(OscProbCalcer yaml-cpp)
+target_link_libraries(OscProbCalcer yaml-cpp NuOscillatorCompilerOptions)
 
 target_include_directories(OscProbCalcer PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>

--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -38,7 +38,6 @@ if(${UseCUDAProb3Linear} EQUAL 1)
 	   	      set_source_files_properties(OscProbCalcer_CUDAProb3Linear.cpp PROPERTIES LANGUAGE CUDA)
 		      target_include_directories(OscProbCalcer PRIVATE ${CUDAProb3_SOURCE_DIR})
 	   endif()
-	   target_compile_options(OscProbCalcer PUBLIC -DGPU_ON=1)
 	   list(APPEND HEADERS OscProbCalcer_CUDAProb3Linear.h)
 endif()
 

--- a/Oscillator/CMakeLists.txt
+++ b/Oscillator/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(Oscillator PRIVATE ../OscProbCalcer PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(Oscillator OscProbCalcer yaml-cpp ROOT::ROOT)
+target_link_libraries(Oscillator OscProbCalcer yaml-cpp ROOT::ROOT NuOscillatorCompilerOptions)
 
 set_target_properties(Oscillator PROPERTIES 
 				 EXPORT_NAME Oscillator)

--- a/cmake/Templates/setup.NuOscillator.sh.in
+++ b/cmake/Templates/setup.NuOscillator.sh.in
@@ -1,2 +1,67 @@
-export CUDAProb3Source=@CUDAProb3_SOURCE_DIR@
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:@LIBDEST@:@yaml-cpp_BINARY_DIR@
+#!/bin/bash
+
+if ! type add_to_PATH &> /dev/null; then
+
+### Adapted from https://unix.stackexchange.com/questions/4965/keep-duplicates-out-of-path-on-source
+function add_to_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/bin" ] || [ "$d" == "/usr/bin64" ] || [ "$d" == "/usr/local/bin" ] || [ "$d" == "/usr/local/bin64" ]; then
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$PATH:$d;;
+      esac
+    else
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$d:$PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+if ! type add_to_LD_LIBRARY_PATH &> /dev/null; then
+
+function add_to_LD_LIBRARY_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/lib" ] || [ "$d" == "/usr/lib64" ] || [ "$d" == "/usr/local/lib" ] || [ "$d" == "/usr/local/lib64" ]; then
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d;;
+      esac
+    else
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$d:$LD_LIBRARY_PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+#if it was sourced as . setup.sh then you can't scrub off the end... assume that
+#we are in the correct directory.
+if ! echo "${BASH_SOURCE}" | grep "/" --silent; then
+  SETUPDIR=$(readlink -f ${PWD}/..)
+else
+  SETUPDIR=$(readlink -f ${BASH_SOURCE%/*}/..)
+fi
+
+export NUOSCILLATOR_ROOT=${SETUPDIR}
+export NUOSCILLATOR_VERSION=@NUOSCILLATOR_VERSION@
+export CUDAProb3_DIR=@CUDAProb3_SOURCE_DIR@
+
+add_to_PATH ${NUOSCILLATOR_ROOT}/Apps
+add_to_LD_LIBRARY_PATH ${NUOSCILLATOR_ROOT}/lib
+
+unset SETUPDIR


### PR DESCRIPTION
-Add NuOscillator Compiler Options interface, this ensure that whetever targets NuOsicllator will proeprly set Dan Double etc.
-Fix weird logic with setting GPU...
-Allow to set via cmake compiler flags both for CPU and GPU

Testing:
Here is example how -DUseDouble is being used in MaCh3 (outisde of NuOscllator)
![image](https://github.com/dbarrow257/NuOscillator/assets/45295406/872717f8-ea6b-4649-bd7a-27d94911ec56)

Setting flags I was able to set long long via cpm when compiling NuuuuOsiclator
![image](https://github.com/dbarrow257/NuOscillator/assets/45295406/d387c656-0cd8-4c68-a766-15ba8631fee6)
![image](https://github.com/dbarrow257/NuOscillator/assets/45295406/710a0c76-d910-4e5c-95ec-95e039de79d0)


This is NuOscillator export target list with:
![image](https://github.com/dbarrow257/NuOscillator/assets/45295406/ca33f9ed-5365-48a4-bd2f-385d462d9f29)
