### PR TITLE
Desctructor and vectors by reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ CUDAProb3/
 Prob3plusplus/
 ProbGPU/
 
+*.pdf
 build/

--- a/Apps/DragRace.cpp
+++ b/Apps/DragRace.cpp
@@ -83,7 +83,7 @@ int main() {
   ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
 #endif
   */
-  
+
   //Alternative option to show how all information can be held in a single YAML file rather than using a preset
   //ConfigNames.push_back("./Configs/CUDAProb3_Binned-SelfContainedFile.yaml");
 
@@ -141,15 +141,15 @@ int main() {
 
       auto t1_single = high_resolution_clock::now();
       if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
-	Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
       } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
-	Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
       } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-	Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
       } else {
-	std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
-	std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;
-	throw;
+        std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
+        std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;
+        throw;
       }
       auto t2_single = high_resolution_clock::now();
       duration<double, std::milli> ms_single_double = t2_single-t1_single;
@@ -185,4 +185,10 @@ int main() {
 
   std::cout << "Finished drag race in executable" << std::endl;
   std::cout << "========================================================" << std::endl;
+
+  for (size_t iOsc = 0; iOsc < Oscillators.size(); iOsc++) {
+    delete Oscillators[iOsc];
+  }
+  Oscillators.clear();
+  delete OscFactory;
 }

--- a/Apps/OscProbCalcerComparison.cpp
+++ b/Apps/OscProbCalcerComparison.cpp
@@ -76,7 +76,7 @@ int main() {
 #if UseProb3ppLinear == 1
   ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
 #endif
-  
+
 #if UseCUDAProb3 == 1
   ConfigNames.push_back("./Configs/Unbinned_CUDAProb3.yaml");
 #endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ install(FILES "${PROJECT_BINARY_DIR}/setup.NuOscillator.sh" DESTINATION ${CMAKE_
 
 install(DIRECTORY Configs DESTINATION ${CMAKE_INSTALL_PREFIX}/)
 install(DIRECTORY Inputs DESTINATION ${CMAKE_INSTALL_PREFIX}/)
+install(DIRECTORY Constants DESTINATION ${CMAKE_INSTALL_PREFIX}/)
 
 set_target_properties(NuOscillatorCompilerOptions PROPERTIES EXPORT_NAME CompilerOptions)
 install(TARGETS NuOscillatorCompilerOptions

--- a/OscProbCalcer/OscProbCalcerBase.cpp
+++ b/OscProbCalcer/OscProbCalcerBase.cpp
@@ -1,4 +1,4 @@
-#include "OscProbCalcerBase.h"
+#include "OscProbCalcer/OscProbCalcerBase.h"
 
 #include <cmath>
 #include <math.h>
@@ -248,7 +248,7 @@ std::vector<OscillationProbability> OscProbCalcerBase::ReturnProbabilities() {
   return ReturnVec;
 }
 
-void OscProbCalcerBase::Reweight(std::vector<FLOAT_T> OscParams) {
+void OscProbCalcerBase::Reweight(const std::vector<FLOAT_T>& OscParams) {
   if (fVerbose >= INFO) {std::cout << "Implementation:" << fImplementationName << " starting reweight" << std::endl;}
 
   if ((int)OscParams.size() != fNOscParams) {
@@ -269,7 +269,7 @@ void OscProbCalcerBase::Reweight(std::vector<FLOAT_T> OscParams) {
 }
 
 void OscProbCalcerBase::SanitiseProbabilities() {
-  for (int iWeight=0;iWeight<fNWeights;iWeight++) {
+  for (int iWeight=0;iWeight<fNWeights;++iWeight) {
     if (std::isnan(fWeightArray[iWeight]) || fWeightArray[iWeight] < 0.0 || fWeightArray[iWeight] > 1.0) {
       std::cerr << "Found unreasonable weight in fWeightArray" << std::endl;
       std::cerr << "iWeight:" << iWeight << std::endl;
@@ -279,8 +279,8 @@ void OscProbCalcerBase::SanitiseProbabilities() {
   }
 }
 
-bool OscProbCalcerBase::AreOscParamsChanged(std::vector<FLOAT_T> OscParamsToCheck) {
-  for (int iParam=0;iParam<fNOscParams;iParam++) {
+bool OscProbCalcerBase::AreOscParamsChanged(const std::vector<FLOAT_T>& OscParamsToCheck) {
+  for (int iParam=0;iParam<fNOscParams;++iParam) {
     if (OscParamsToCheck[iParam] != fOscParamsCurr[iParam]) {
       if (fVerbose >= INFO) {std::cout << "Implementation:" << fImplementationName << " was found to have different oscillation parameters than the previous calculation" << std::endl;}
       return true;
@@ -294,7 +294,7 @@ void OscProbCalcerBase::ResetCurrOscParams() {
   fOscParamsCurr = std::vector<FLOAT_T>(fNOscParams,DUMMYVAL);
 }
 
-void OscProbCalcerBase::SetCurrOscParams(std::vector<FLOAT_T> OscParamsToSave) {
+void OscProbCalcerBase::SetCurrOscParams(const std::vector<FLOAT_T>& OscParamsToSave) {
   for (int iParam=0;iParam<fNOscParams;iParam++) {
     fOscParamsCurr[iParam] = OscParamsToSave[iParam];
   }

--- a/OscProbCalcer/OscProbCalcerBase.h
+++ b/OscProbCalcer/OscProbCalcerBase.h
@@ -70,7 +70,7 @@ class OscProbCalcerBase {
    *
    * @param OscParams The oscillation parameters to calculate the oscillation probability at
    */
-  void Reweight(std::vector<FLOAT_T> OscParams);
+  void Reweight(const std::vector<FLOAT_T>& OscParams);
 
   /**
    * @brief General function used to setup all variables used within the reweighting
@@ -216,7 +216,7 @@ class OscProbCalcerBase {
    * @param OscParamsToCheck The oscillation parameters which have been requested for the next calculation
    * @return Boolean whether the OscParamsToCheck match those saved from the last calculation
    */
-  bool AreOscParamsChanged(std::vector<FLOAT_T> OscParamsToCheck);
+  bool AreOscParamsChanged(const std::vector<FLOAT_T>& OscParamsToCheck);
 
   /**
    * @brief Save the oscillation parameters which have been requested
@@ -225,7 +225,7 @@ class OscProbCalcerBase {
    *
    * @param OscParamsToCheck Parameter set to save
    */
-  void SetCurrOscParams(std::vector<FLOAT_T> OscParamsToCheck);
+  void SetCurrOscParams(const std::vector<FLOAT_T>& OscParamsToCheck);
 
   /**
    * @brief (Re-)Initialise the saved oscillation parameters in #fOscParamsCurr
@@ -312,7 +312,7 @@ class OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  virtual void CalculateProbabilities(std::vector<FLOAT_T> OscParams) = 0;
+  virtual void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) = 0;
 
   /**
    * @brief Setup any implementation specific variables/functions

--- a/OscProbCalcer/OscProbCalcerBase.h
+++ b/OscProbCalcer/OscProbCalcerBase.h
@@ -21,14 +21,6 @@ class OscProbCalcerBase {
   // Public functions which are calculation implementation agnostic
 
    /**
-    * @brief Default constructor
-    *
-    * @param ConfigName_ Name of YAML config used to set runtime variables
-    * @param Instance_ Instance in the OscProbCalcerSetup YAML Node to select
-    */
-   OscProbCalcerBase(std::string ConfigName_, std::string ImplementationName_, int Instance_=0);
-
-   /**
     * @brief Destructor
     */
    virtual ~OscProbCalcerBase();
@@ -193,6 +185,16 @@ class OscProbCalcerBase {
   // Public virtual functions which need calculater specific implementations
 
  protected:
+   /**
+    * @brief Default constructor
+    *
+    * @details It is protected to prevent initialisation of base class
+    *
+    * @param ConfigName_ Name of YAML config used to set runtime variables
+    * @param Instance_ Instance in the OscProbCalcerSetup YAML Node to select
+    */
+   OscProbCalcerBase(std::string ConfigName_, std::string ImplementationName_, int Instance_=0);
+
   // ========================================================================================================================================================================
   // Protected functions which are calculation implementation agnostic  
 

--- a/OscProbCalcer/OscProbCalcerBase.h
+++ b/OscProbCalcer/OscProbCalcerBase.h
@@ -20,6 +20,19 @@ class OscProbCalcerBase {
   // ========================================================================================================================================================================
   // Public functions which are calculation implementation agnostic
 
+   /**
+    * @brief Default constructor
+    *
+    * @param ConfigName_ Name of YAML config used to set runtime variables
+    * @param Instance_ Instance in the OscProbCalcerSetup YAML Node to select
+    */
+   OscProbCalcerBase(std::string ConfigName_, std::string ImplementationName_, int Instance_=0);
+
+   /**
+    * @brief Destructor
+    */
+   virtual ~OscProbCalcerBase();
+
   /**
    * @brief Define the Energy which will be used when calculating the oscillation probabilities
    * 
@@ -180,20 +193,6 @@ class OscProbCalcerBase {
   // Public virtual functions which need calculater specific implementations
 
  protected:
-
-  /**
-   * @brief Default constructor
-   *
-   * @param ConfigName_ Name of YAML config used to set runtime variables
-   * @param Instance_ Instance in the OscProbCalcerSetup YAML Node to select
-   */
-  OscProbCalcerBase(std::string ConfigName_, std::string ImplementationName_, int Instance_=0);
-
-
-  /**
-   * @brief Destructor
-   */
-  virtual ~OscProbCalcerBase();
   // ========================================================================================================================================================================
   // Protected functions which are calculation implementation agnostic  
 

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -49,6 +49,10 @@ OscProbCalcerCUDAProb3::OscProbCalcerCUDAProb3(std::string ConfigName_, int Inst
   nThreads = 1;
 }
 
+OscProbCalcerCUDAProb3::~OscProbCalcerCUDAProb3() {
+
+}
+
 void OscProbCalcerCUDAProb3::SetupPropagator() {
 
 #if UseGPU == 1

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.h
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.h
@@ -29,6 +29,11 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    */
   OscProbCalcerCUDAProb3(std::string ConfigName_="", int Instance_=0);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerCUDAProb3();
+
  private:
   // ========================================================================================================================================================================
   // Functions which need implementation specific code

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.h
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.h
@@ -43,7 +43,7 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    *
    * Setup the cudaprob3::Propagator instance and set all of the variables that it needs like EarthModel etc.
    */
-  void SetupPropagator();
+  void SetupPropagator() override;
 
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -53,7 +53,7 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(std::vector<FLOAT_T> OscParams) override;
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -65,7 +65,7 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
-  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1);
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1) override;
 
   /**
    * @brief Define the size of fWeightArray
@@ -74,7 +74,7 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    *
    * @return Length that #fWeightArray should be initialised to
    */
-  long DefineWeightArraySize();
+  long DefineWeightArraySize() override;
   
   // ========================================================================================================================================================================
   //Functions which help setup implementation specific code

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
@@ -48,6 +48,11 @@ OscProbCalcerCUDAProb3Linear::OscProbCalcerCUDAProb3Linear(std::string ConfigNam
   nThreads = 1;
 }
 
+
+OscProbCalcerCUDAProb3Linear::~OscProbCalcerCUDAProb3Linear() {
+
+}
+
 void OscProbCalcerCUDAProb3Linear::SetupPropagator() {
 
 #if UseGPU == 1

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
@@ -80,7 +80,7 @@ void OscProbCalcerCUDAProb3Linear::SetupPropagator() {
   if (fVerbose >= INFO) {std::cout << "Setup CUDAProb3Linear oscillation probability calculater" << std::endl;}
 }
  
-void OscProbCalcerCUDAProb3Linear::CalculateProbabilities(std::vector<FLOAT_T> OscParams) {
+void OscProbCalcerCUDAProb3Linear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
   // Oscpars, as given from MaCh3, expresses the mixing angles in sin^2(theta). This propagator expects them in theta
   for (int iOscPar=0;iOscPar<=kTH13;iOscPar++) {
     if (OscParams[iOscPar] < 0) {

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.h
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.h
@@ -44,7 +44,7 @@ class OscProbCalcerCUDAProb3Linear : public OscProbCalcerBase {
    *
    * Setup the cudaprob3::Propagator instance and set all of the variables that it needs like EarthModel etc.
    */
-  void SetupPropagator();
+  void SetupPropagator() override;
 
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -54,7 +54,7 @@ class OscProbCalcerCUDAProb3Linear : public OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -66,7 +66,7 @@ class OscProbCalcerCUDAProb3Linear : public OscProbCalcerBase {
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
-  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1);
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1) override;
 
   /**
    * @brief Define the size of fWeightArray
@@ -75,7 +75,7 @@ class OscProbCalcerCUDAProb3Linear : public OscProbCalcerBase {
    *
    * @return Length that #fWeightArray should be initialised to
    */
-  long DefineWeightArraySize();
+  long DefineWeightArraySize() override;
   
   // ========================================================================================================================================================================
   //Functions which help setup implementation specific code

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.h
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.h
@@ -30,6 +30,11 @@ class OscProbCalcerCUDAProb3Linear : public OscProbCalcerBase {
    */
   OscProbCalcerCUDAProb3Linear(std::string ConfigName_="", int Instance_=0);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerCUDAProb3Linear();
+
  private:
   // ========================================================================================================================================================================
   // Functions which need implementation specific code

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -29,7 +29,7 @@ OscProbCalcerNuFASTLinear::~OscProbCalcerNuFASTLinear() {
 void OscProbCalcerNuFASTLinear::SetupPropagator() {
 }
 
-void OscProbCalcerNuFASTLinear::CalculateProbabilities(std::vector<FLOAT_T> OscParams) {
+void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
   double L, E, rho, Ye, probs_returned[3][3];
   double s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31;
   int N_Newton;
@@ -65,7 +65,7 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(std::vector<FLOAT_T> OscP
   // Calculate all 9 oscillationa probabilities //
   // ------------------------------------------ //
 
-  for (int iOscProb=0;iOscProb<fNEnergyPoints;iOscProb++) {    
+  for (int iOscProb=0;iOscProb<fNEnergyPoints;iOscProb++) {
     for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
       
       //+ve energy for neutrinos, -ve energy for antineutrinos

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -22,6 +22,10 @@ OscProbCalcerNuFASTLinear::OscProbCalcerNuFASTLinear(std::string ConfigName_, in
   IgnoreCosineZBinning(true);
 }
 
+OscProbCalcerNuFASTLinear::~OscProbCalcerNuFASTLinear() {
+
+}
+
 void OscProbCalcerNuFASTLinear::SetupPropagator() {
 }
 

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.h
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.h
@@ -32,7 +32,7 @@ class OscProbCalcerNuFASTLinear : public OscProbCalcerBase {
   /**
    * @brief Setup NuFAST specific variables
    */  
-  void SetupPropagator();
+  void SetupPropagator() override;
   
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -42,7 +42,7 @@ class OscProbCalcerNuFASTLinear : public OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -54,7 +54,7 @@ class OscProbCalcerNuFASTLinear : public OscProbCalcerBase {
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
-  int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1);
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1) override;
   
   /**
    * @brief Define the size of fWeightArray
@@ -63,7 +63,7 @@ class OscProbCalcerNuFASTLinear : public OscProbCalcerBase {
    *
    * @return Length that #fWeightArray should be initialised to
    */
-  long DefineWeightArraySize();
+  long DefineWeightArraySize() override;
 
   // ========================================================================================================================================================================
   // Functions which help setup implementation specific code

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.h
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.h
@@ -21,6 +21,11 @@ class OscProbCalcerNuFASTLinear : public OscProbCalcerBase {
    */
   OscProbCalcerNuFASTLinear(std::string ConfigName_="", int Instance_=0);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerNuFASTLinear();
+
   // ========================================================================================================================================================================
   // Functions which need implementation specific code
 

--- a/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
@@ -21,6 +21,8 @@ OscProbCalcerProb3ppLinear::OscProbCalcerProb3ppLinear(std::string ConfigName_, 
 
   // Implementation specific variables
   doubled_angle = true;
+
+  bNu = nullptr;
 }
 
 OscProbCalcerProb3ppLinear::~OscProbCalcerProb3ppLinear() {
@@ -35,8 +37,8 @@ void OscProbCalcerProb3ppLinear::SetupPropagator() {
    bNu->SetWarningSuppression(true);
 }
 
-void OscProbCalcerProb3ppLinear::CalculateProbabilities(std::vector<FLOAT_T> OscParams) {
-  // Prob3++ calculates oscillation probabilites for each NeutrinoType and each energy, so need to copy them from the calculator into fWeightArray
+void OscProbCalcerProb3ppLinear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
+  // Prob3++ calculates oscillation probabilities for each NeutrinoType and each energy, so need to copy them from the calculator into fWeightArray
   for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
     for (int iOscChannel=0;iOscChannel<fNOscillationChannels;iOscChannel++) {
     

--- a/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
@@ -23,6 +23,11 @@ OscProbCalcerProb3ppLinear::OscProbCalcerProb3ppLinear(std::string ConfigName_, 
   doubled_angle = true;
 }
 
+OscProbCalcerProb3ppLinear::~OscProbCalcerProb3ppLinear() {
+
+  if(bNu != nullptr) delete bNu;
+}
+
 void OscProbCalcerProb3ppLinear::SetupPropagator() {
    bNu = new BargerPropagator();
    bNu->UseMassEigenstates(false);
@@ -39,9 +44,9 @@ void OscProbCalcerProb3ppLinear::CalculateProbabilities(std::vector<FLOAT_T> Osc
       int IndexToFill = iNuType*fNOscillationChannels*fNEnergyPoints + iOscChannel*fNEnergyPoints;
       
       for (int iOscProb=0;iOscProb<fNEnergyPoints;iOscProb++) {
-	bNu->SetMNS(OscParams[kTH12], OscParams[kTH13], OscParams[kTH23], OscParams[kDM12], OscParams[kDM23], OscParams[kDCP], fEnergyArray[iOscProb], doubled_angle, fNeutrinoTypes[iNuType]);
-	bNu->propagateLinear(fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].GeneratedFlavour, OscParams[kPATHL], OscParams[kDENS]);
-	fWeightArray[IndexToFill+iOscProb] = bNu->GetProb(fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].GeneratedFlavour, fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].DetectedFlavour);
+        bNu->SetMNS(OscParams[kTH12], OscParams[kTH13], OscParams[kTH23], OscParams[kDM12], OscParams[kDM23], OscParams[kDCP], fEnergyArray[iOscProb], doubled_angle, fNeutrinoTypes[iNuType]);
+        bNu->propagateLinear(fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].GeneratedFlavour, OscParams[kPATHL], OscParams[kDENS]);
+        fWeightArray[IndexToFill+iOscProb] = bNu->GetProb(fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].GeneratedFlavour, fNeutrinoTypes[iNuType]*fOscillationChannels[iOscChannel].DetectedFlavour);
       }
     }
   }

--- a/OscProbCalcer/OscProbCalcer_Prob3ppLinear.h
+++ b/OscProbCalcer/OscProbCalcer_Prob3ppLinear.h
@@ -34,7 +34,7 @@ class OscProbCalcerProb3ppLinear : public OscProbCalcerBase {
   /**
    * @brief Setup Prob3pp specific variables like the BargerPropagator #bNu
    */  
-  void SetupPropagator();
+  void SetupPropagator() override;
   
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -44,7 +44,7 @@ class OscProbCalcerProb3ppLinear : public OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -56,7 +56,7 @@ class OscProbCalcerProb3ppLinear : public OscProbCalcerBase {
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
-  int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1);
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1) override;
   
   /**
    * @brief Define the size of fWeightArray
@@ -65,7 +65,7 @@ class OscProbCalcerProb3ppLinear : public OscProbCalcerBase {
    *
    * @return Length that #fWeightArray should be initialised to
    */
-  long DefineWeightArraySize();
+  long DefineWeightArraySize() override;
 
   // ========================================================================================================================================================================
   // Functions which help setup implementation specific code

--- a/OscProbCalcer/OscProbCalcer_Prob3ppLinear.h
+++ b/OscProbCalcer/OscProbCalcer_Prob3ppLinear.h
@@ -23,6 +23,11 @@ class OscProbCalcerProb3ppLinear : public OscProbCalcerBase {
    */
   OscProbCalcerProb3ppLinear(std::string ConfigName_="", int Instance_=0);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerProb3ppLinear();
+
   // ========================================================================================================================================================================
   // Functions which need implementation specific code
 

--- a/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
@@ -27,17 +27,17 @@ OscProbCalcerProbGPULinear::OscProbCalcerProbGPULinear(std::string ConfigName_, 
 }
 
 OscProbCalcerProbGPULinear::~OscProbCalcerProbGPULinear() {
-  if(CopyArr != nullptr) delete[] CopyArr;
+
 }
 
 void OscProbCalcerProbGPULinear::SetupPropagator() {
   // This implementation doesn't really need to do anything in the setup due to probGPU's horrific implementation
 }
 
-void OscProbCalcerProbGPULinear::CalculateProbabilities(std::vector<FLOAT_T> OscParams) {
+void OscProbCalcerProbGPULinear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
   setMNS(OscParams[kTH12], OscParams[kTH13], OscParams[kTH23], OscParams[kDM12], OscParams[kDM23], OscParams[kDCP], doubled_angle);
 
-  // ProbGPULinear calculates oscillation probabilites for each NeutrinoType, so need to copy them from the calculator into fWeightArray
+  // ProbGPULinear calculates oscillation probabilities for each NeutrinoType, so need to copy them from the calculator into fWeightArray
   int CopyArrSize = fNEnergyPoints;
   FLOAT_T* CopyArr = new FLOAT_T[CopyArrSize];
 
@@ -52,6 +52,7 @@ void OscProbCalcerProbGPULinear::CalculateProbabilities(std::vector<FLOAT_T> Osc
       }
     }
   }
+  delete[] CopyArr;
 }
 
 int OscProbCalcerProbGPULinear::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex) {

--- a/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
@@ -26,6 +26,10 @@ OscProbCalcerProbGPULinear::OscProbCalcerProbGPULinear(std::string ConfigName_, 
   doubled_angle = true;
 }
 
+OscProbCalcerProbGPULinear::~OscProbCalcerProbGPULinear() {
+  if(CopyArr != nullptr) delete[] CopyArr;
+}
+
 void OscProbCalcerProbGPULinear::SetupPropagator() {
   // This implementation doesn't really need to do anything in the setup due to probGPU's horrific implementation
 }
@@ -44,7 +48,7 @@ void OscProbCalcerProbGPULinear::CalculateProbabilities(std::vector<FLOAT_T> Osc
       // Mapping which links the oscillation channel, neutrino type and energy index to the fWeightArray index
       int IndexToFill = iNuType*fNOscillationChannels*CopyArrSize + iOscChannel*CopyArrSize;
       for (int iOscProb=0;iOscProb<CopyArrSize;iOscProb++) {
-	fWeightArray[IndexToFill+iOscProb] = CopyArr[iOscProb];
+        fWeightArray[IndexToFill+iOscProb] = CopyArr[iOscProb];
       }
     }
   }

--- a/OscProbCalcer/OscProbCalcer_ProbGPULinear.h
+++ b/OscProbCalcer/OscProbCalcer_ProbGPULinear.h
@@ -34,7 +34,7 @@ class OscProbCalcerProbGPULinear : public OscProbCalcerBase {
    *
    * ProbGPU implementation is horrible, meaning that this function doesn't need to do anything
    */  
-  void SetupPropagator();
+  void SetupPropagator() override;
 
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -44,7 +44,7 @@ class OscProbCalcerProbGPULinear : public OscProbCalcerBase {
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -56,7 +56,7 @@ class OscProbCalcerProbGPULinear : public OscProbCalcerBase {
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
-  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1);
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex=-1) override;
 
     /**
    * @brief Define the size of fWeightArray
@@ -65,7 +65,7 @@ class OscProbCalcerProbGPULinear : public OscProbCalcerBase {
    *
    * @return Length that #fWeightArray should be initialised to
    */
-  long DefineWeightArraySize();
+  long DefineWeightArraySize() override;
 
   // ========================================================================================================================================================================
   // Functions which help setup implementation specific code

--- a/OscProbCalcer/OscProbCalcer_ProbGPULinear.h
+++ b/OscProbCalcer/OscProbCalcer_ProbGPULinear.h
@@ -21,6 +21,11 @@ class OscProbCalcerProbGPULinear : public OscProbCalcerBase {
    */
   OscProbCalcerProbGPULinear(std::string ConfigName_="", int Instance_=0);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerProbGPULinear();
+
   // ========================================================================================================================================================================
   // Functions which need implementation specific code
 

--- a/Oscillator/OscillatorBase.cpp
+++ b/Oscillator/OscillatorBase.cpp
@@ -58,6 +58,9 @@ OscillatorBase::OscillatorBase(std::string ConfigName_) {
 
 OscillatorBase::~OscillatorBase() {
 
+  for (size_t iOsc = 0; iOsc < fOscProbCalcers.size(); iOsc++) {
+    delete fOscProbCalcers[iOsc];
+  }
 }
 
 void OscillatorBase::InitialiseOscProbCalcers() {

--- a/Oscillator/OscillatorBase.h
+++ b/Oscillator/OscillatorBase.h
@@ -23,6 +23,19 @@ class OscillatorBase {
   // ========================================================================================================================================================================
   // Public functions which are calculation implementation agnostic
 
+   /**
+    * @brief Default constructor
+    *
+    * @param ConfigName_ YAML config file used to set runtime constants
+    */
+   OscillatorBase(std::string ConfigName_);
+
+
+   /**
+    * @brief Destructor
+    */
+   virtual ~OscillatorBase();
+
   /**
    * @brief Perform a sanity check which ensures that #fOscProbCalcers have been set correctly.
    *
@@ -177,19 +190,6 @@ class OscillatorBase {
  protected:
   // ========================================================================================================================================================================
   // Protected functions which are calculation implementation agnostic
-
-  /**
-   * @brief Default constructor
-   *
-   * @param ConfigName_ YAML config file used to set runtime constants
-   */
-  OscillatorBase(std::string ConfigName_);
-
-
-  /**
-   * @brief Destructor
-   */
-  virtual ~OscillatorBase();
 
   /**
    * @brief Return a pointer to the oscillation probability memory address in a particular index of #fOscProbCalcers for a particular event

--- a/Oscillator/OscillatorBase.h
+++ b/Oscillator/OscillatorBase.h
@@ -19,22 +19,13 @@
  */
 class OscillatorBase {
  public:
-
-  // ========================================================================================================================================================================
-  // Public functions which are calculation implementation agnostic
-
-   /**
-    * @brief Default constructor
-    *
-    * @param ConfigName_ YAML config file used to set runtime constants
-    */
-   OscillatorBase(std::string ConfigName_);
-
-
    /**
     * @brief Destructor
     */
    virtual ~OscillatorBase();
+
+  // ========================================================================================================================================================================
+  // Public functions which are calculation implementation agnostic
 
   /**
    * @brief Perform a sanity check which ensures that #fOscProbCalcers have been set correctly.
@@ -188,6 +179,16 @@ class OscillatorBase {
   virtual const FLOAT_T* ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal=DUMMYVAL) = 0;
 
  protected:
+   /**
+    * @brief Default constructor
+    *
+    * @details It is protected to prevent initialisation of base class
+    *
+    * @param ConfigName_ YAML config file used to set runtime constants
+    */
+   OscillatorBase(std::string ConfigName_);
+
+
   // ========================================================================================================================================================================
   // Protected functions which are calculation implementation agnostic
 

--- a/Oscillator/OscillatorBinned.cpp
+++ b/Oscillator/OscillatorBinned.cpp
@@ -41,6 +41,11 @@ OscillatorBinned::OscillatorBinned(std::string ConfigName_) : OscillatorBase(Con
 
 }
 
+
+OscillatorBinned::~OscillatorBinned() {
+
+}
+
 std::vector<FLOAT_T> OscillatorBinned::ReadBinEdgesFromFile(std::string FileName, std::string HistogramName, bool IsCosineZAxis) {
   std::vector<FLOAT_T> BinEdges;
 

--- a/Oscillator/OscillatorBinned.cpp
+++ b/Oscillator/OscillatorBinned.cpp
@@ -1,4 +1,4 @@
-#include "OscillatorBinned.h"
+#include "Oscillator/OscillatorBinned.h"
 
 #include <iostream>
 

--- a/Oscillator/OscillatorBinned.h
+++ b/Oscillator/OscillatorBinned.h
@@ -25,6 +25,11 @@ class OscillatorBinned : public OscillatorBase {
    */
   OscillatorBinned(std::string ConfigName_);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscillatorBinned();
+
   // ========================================================================================================================================================================
   // Public functions which are calculation implementation agnostic
 

--- a/Oscillator/OscillatorFactory.cpp
+++ b/Oscillator/OscillatorFactory.cpp
@@ -5,6 +5,10 @@
 OscillatorFactory::OscillatorFactory() {
 }
 
+OscillatorFactory::~OscillatorFactory() {
+
+}
+
 OscillatorBase* OscillatorFactory::CreateOscillator(std::string ConfigName_) {
   // Create config manager
   std::cout << "OscillatorFactory creating OscillatorBase object from config: " << ConfigName_ << std::endl;

--- a/Oscillator/OscillatorFactory.cpp
+++ b/Oscillator/OscillatorFactory.cpp
@@ -1,4 +1,4 @@
-#include "OscillatorFactory.h"
+#include "Oscillator/OscillatorFactory.h"
 
 #include <iostream>
 

--- a/Oscillator/OscillatorFactory.h
+++ b/Oscillator/OscillatorFactory.h
@@ -21,6 +21,11 @@ class OscillatorFactory {
   OscillatorFactory();
 
   /**
+   * @brief Destructor
+   */
+  virtual ~OscillatorFactory();
+
+  /**
    * @brief Create an instance of OscillatorBase::OscillatorBase() objects from a YAML config. This currently includes OscillatorBinned::OscillatorBinned() and 
    * OscillatorUnbinned::OscillatorUnbinned() objects
    *

--- a/Oscillator/OscillatorUnbinned.cpp
+++ b/Oscillator/OscillatorUnbinned.cpp
@@ -1,4 +1,4 @@
-#include "OscillatorUnbinned.h"
+#include "Oscillator/OscillatorUnbinned.h"
 
 #include <iostream>
 

--- a/Oscillator/OscillatorUnbinned.cpp
+++ b/Oscillator/OscillatorUnbinned.cpp
@@ -6,6 +6,10 @@ OscillatorUnbinned::OscillatorUnbinned(std::string ConfigName_) : OscillatorBase
   fCalculationTypeName = "Unbinned";
 }
 
+OscillatorUnbinned::~OscillatorUnbinned() {
+
+}
+
 const FLOAT_T* OscillatorUnbinned::ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal) {
   int CalcerIndex = 0;
   const FLOAT_T* Pointer = ReturnPointerToWeightinCalcer(CalcerIndex,InitNuFlav,FinalNuFlav,EnergyVal,CosineZVal);

--- a/Oscillator/OscillatorUnbinned.h
+++ b/Oscillator/OscillatorUnbinned.h
@@ -25,6 +25,11 @@ class OscillatorUnbinned : public OscillatorBase {
    */
   OscillatorUnbinned(std::string ConfigName_);
 
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscillatorUnbinned();
+
   // ========================================================================================================================================================================
   // Public functions which are calculation implementation agnostic
 


### PR DESCRIPTION
## List of changes
- Now all destructors are public which means we can actually delete objects
- Some objects were not deleted most notably temp arrays in ProbGPU :(
- Use override to help indicate that fucntions overrides virtual in base class
- Install in cmake new constants directory
- Safer headers with total path
- Pass vectors by reference instead of copying did short test
before
<img width="876" alt="before" src="https://github.com/user-attachments/assets/77a7636e-93d3-461d-bf0f-5efc43313fa9">

after
<img width="872" alt="after" src="https://github.com/user-attachments/assets/c5c8ae6c-48f0-41c5-bb98-b9371e2553dc">
