### PR TITLE
Fix antineutrino support

### DIFF
--- a/OscProbCalcer/OscProbCalcerBase.cpp
+++ b/OscProbCalcer/OscProbCalcerBase.cpp
@@ -170,7 +170,7 @@ const FLOAT_T* OscProbCalcerBase::ReturnPointerToWeight(int InitNuFlav, int Fina
   }
 
   int NuTypeIndex = ReturnNuTypeFromFlavour(InitNuFlav);
-  int OscChanIndex = ReturnOscChannelIndexFromFlavours(InitNuFlav,FinalNuFlav);
+  int OscChanIndex = ReturnOscChannelIndexFromFlavours(std::abs(InitNuFlav),std::abs(FinalNuFlav));
   int CosineZIndex = -1;
   if (!ReturnCosineZIgnored()) {
     CosineZIndex = ReturnCosineZIndexFromValue(CosineZ);

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
@@ -108,13 +108,16 @@ void OscProbCalcerCUDAProb3Linear::CalculateProbabilities(const std::vector<FLOA
 
   for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
 
+    int NuType_int;
     cudaprob3::NeutrinoType NuType;
     if (fNeutrinoTypes[iNuType]==Nubar) {
+      NuType_int = -1;
       NuType = cudaprob3::Antineutrino;
     } else {
+      NuType_int = 1;
       NuType = cudaprob3::Neutrino;
     }
-    propagator->setMNSMatrix(theta12, theta13, theta23, dcp, NuType);
+    propagator->setMNSMatrix(theta12, theta13, theta23, dcp, NuType_int);
 
     propagator->calculateProbabilities(NuType);
 


### PR DESCRIPTION
# Pull request description:
Fix antineutrino support

## Changes or fixes:
Fix the index finding for antineutrinos which are given a negative oscillation channel and similarly, fix the antineutrino support in CUDAProb3Linear which [after Liban's changes] no longer uses the cudaprob3::Antineutrino type to determine whether an event is neutrino or antineutrino

## Examples:
