### PR TITLE
Cmake Fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
     project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX CUDA)
 endif()
 
-LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
+LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 #Changes default install path to be a subdirectory of the build dir.
 #Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path


### PR DESCRIPTION
# Pull request description:
When you CPM NuOsc then CMAKE_SOURCE_DIR will point out to somethign else. Use PROJECT_SOURCE_DIR so it really points to NuOsc path.

## Changes or fixes:


## Examples:
