### PR TITLE
Move oscillation parameters and configs to the constants structure

### DIFF
--- a/Apps/Analysis.cpp
+++ b/Apps/Analysis.cpp
@@ -17,6 +17,10 @@ int main() {
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
 
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+
   std::cout << "========================================================" << std::endl;
   std::cout << "Starting setup in executable" << std::endl;
 
@@ -67,12 +71,12 @@ int main() {
     
     // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
     // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
-	Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe); 
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+	Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe); 
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/Analysis.cpp
+++ b/Apps/Analysis.cpp
@@ -12,26 +12,7 @@ using std::chrono::duration;
 using std::chrono::milliseconds;
 
 int main() {
-  bool PrintWeights = true;
-
-  std::vector<FLOAT_T> OscParams_Atm(7);
-  OscParams_Atm[0] = 3.07e-1;
-  OscParams_Atm[1] = 5.28e-1;
-  OscParams_Atm[2] = 2.18e-2;
-  OscParams_Atm[3] = 7.53e-5;
-  OscParams_Atm[4] = 2.509e-3;
-  OscParams_Atm[5] = -1.601;
-  OscParams_Atm[6] = 25.0;
-
-  std::vector<FLOAT_T> OscParams_Beam(8);
-  OscParams_Beam[0] = 3.07e-1;
-  OscParams_Beam[1] = 5.28e-1;
-  OscParams_Beam[2] = 2.18e-2;
-  OscParams_Beam[3] = 7.53e-5;
-  OscParams_Beam[4] = 2.509e-3;
-  OscParams_Beam[5] = -1.601;
-  OscParams_Beam[6] = 250.0;
-  OscParams_Beam[7] = 2.6;
+  bool PrintWeights = false;
 
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
@@ -40,34 +21,12 @@ int main() {
   std::cout << "Starting setup in executable" << std::endl;
 
   std::vector<OscillatorBase*> Oscillators;
-  std::vector<std::string> ConfigNames;
-
   OscillatorFactory* OscFactory = new OscillatorFactory();
   OscillatorBase* Oscillator;
 
-#if UseCUDAProb3 == 1
-  ConfigNames.push_back("./Configs/Binned_CUDAProb3.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3.yaml");
-#endif
-
-#if UseCUDAProb3Linear == 1
-  ConfigNames.push_back("./Configs/Binned_CUDAProb3Linear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3Linear.yaml");
-#endif
-
-#if UseProbGPULinear == 1
-  ConfigNames.push_back("./Configs/Binned_ProbGPULinear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_ProbGPULinear.yaml");
-#endif
-
-#if UseProb3ppLinear == 1
-  ConfigNames.push_back("./Configs/Binned_Prob3ppLinear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
-#endif
-
-  //Alternative option to show how all information can be held in a single YAML file rather than using a preset
-  //ConfigNames.push_back("./Configs/CUDAProb3_Binned-SelfContainedFile.yaml");
-
+  //Get the standard set of config names
+  std::vector<std::string> ConfigNames = ReturnKnownConfigs();
+    
   for (size_t iConfig=0;iConfig<ConfigNames.size();iConfig++) {
     std::cout << "========================================================" << std::endl;
     std::cout << "Initialising " << ConfigNames[iConfig] << std::endl;
@@ -104,12 +63,16 @@ int main() {
 
   // Reweight and calculate oscillation probabilities
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
+    std::cout << "Performing reweight in Oscillator: " << iOsc << "/" << Oscillators.size() << std::endl;
+    
     // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
     // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam); 
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
+	Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe); 
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/DragRace.cpp
+++ b/Apps/DragRace.cpp
@@ -15,35 +15,6 @@ using std::chrono::duration;
 using std::chrono::milliseconds;
 
 int main() {
-  std::vector<FLOAT_T> OscParams_Atm(7);
-  OscParams_Atm[0] = 3.07e-1;
-  OscParams_Atm[1] = 5.28e-1;
-  OscParams_Atm[2] = 2.18e-2;
-  OscParams_Atm[3] = 7.53e-5;
-  OscParams_Atm[4] = 2.509e-3;
-  OscParams_Atm[5] = -1.601;
-  OscParams_Atm[6] = 25.0;
-
-  std::vector<FLOAT_T> OscParams_Beam_woYe(8);
-  OscParams_Beam_woYe[0] = 3.07e-1;
-  OscParams_Beam_woYe[1] = 5.28e-1;
-  OscParams_Beam_woYe[2] = 2.18e-2;
-  OscParams_Beam_woYe[3] = 7.53e-5;
-  OscParams_Beam_woYe[4] = 2.509e-3;
-  OscParams_Beam_woYe[5] = -1.601;
-  OscParams_Beam_woYe[6] = 250.0;
-  OscParams_Beam_woYe[7] = 2.6;
-
-  std::vector<FLOAT_T> OscParams_Beam_wYe(9);
-  OscParams_Beam_wYe[0] = 3.07e-1;
-  OscParams_Beam_wYe[1] = 5.28e-1;
-  OscParams_Beam_wYe[2] = 2.18e-2;
-  OscParams_Beam_wYe[3] = 7.53e-5;
-  OscParams_Beam_wYe[4] = 2.509e-3;
-  OscParams_Beam_wYe[5] = -1.601;
-  OscParams_Beam_wYe[6] = 250.0;
-  OscParams_Beam_wYe[7] = 2.6;
-  OscParams_Beam_wYe[8] = 0.5;
   
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e5);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
@@ -135,17 +106,17 @@ int main() {
     for (int iThrow=0;iThrow<nThrows;iThrow++) {
       //Throw dcp to some new value
       FLOAT_T RandVal = static_cast <FLOAT_T> (rand()) / static_cast <FLOAT_T> (RAND_MAX);
-      OscParams_Atm[5] = RandVal;
-      OscParams_Beam_woYe[5] = RandVal;
-      OscParams_Beam_wYe[5] = RandVal;
+      NuOscillator::OscParams_Atm[5] = RandVal;
+      NuOscillator::OscParams_Beam_woYe[5] = RandVal;
+      NuOscillator::OscParams_Beam_wYe[5] = RandVal;
 
       auto t1_single = high_resolution_clock::now();
-      if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
-      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
-      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+      if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
+      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe);
+      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
       } else {
         std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
         std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/DragRace.cpp
+++ b/Apps/DragRace.cpp
@@ -19,44 +19,19 @@ int main() {
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e5);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
 
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+
   std::cout << "========================================================" << std::endl;
   std::cout << "Starting setup in executable" << std::endl;
 
   std::vector<OscillatorBase*> Oscillators;
-  std::vector<std::string> ConfigNames;
-
   OscillatorFactory* OscFactory = new OscillatorFactory();
   OscillatorBase* Oscillator;
 
-#if UseCUDAProb3 == 1
-  ConfigNames.push_back("./Configs/Binned_CUDAProb3.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3.yaml");
-#endif
-
-#if UseNuFASTLinear == 1
-  ConfigNames.push_back("./Configs/Binned_NuFASTLinear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_NuFASTLinear.yaml");
-#endif
-
-#if UseCUDAProb3Linear == 1
-  ConfigNames.push_back("./Configs/Binned_CUDAProb3Linear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3Linear.yaml");
-#endif
-
-#if UseProbGPULinear == 1
-  ConfigNames.push_back("./Configs/Binned_ProbGPULinear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_ProbGPULinear.yaml");
-#endif
-
-  /*
-#if UseProb3ppLinear == 1
-  ConfigNames.push_back("./Configs/Binned_Prob3ppLinear.yaml");
-  ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
-#endif
-  */
-
-  //Alternative option to show how all information can be held in a single YAML file rather than using a preset
-  //ConfigNames.push_back("./Configs/CUDAProb3_Binned-SelfContainedFile.yaml");
+  //Get the standard set of config names
+  std::vector<std::string> ConfigNames = ReturnKnownConfigs();
 
   for (size_t iConfig=0;iConfig<ConfigNames.size();iConfig++) {
     std::cout << "========================================================" << std::endl;
@@ -106,17 +81,17 @@ int main() {
     for (int iThrow=0;iThrow<nThrows;iThrow++) {
       //Throw dcp to some new value
       FLOAT_T RandVal = static_cast <FLOAT_T> (rand()) / static_cast <FLOAT_T> (RAND_MAX);
-      NuOscillator::OscParams_Atm[5] = RandVal;
-      NuOscillator::OscParams_Beam_woYe[5] = RandVal;
-      NuOscillator::OscParams_Beam_wYe[5] = RandVal;
+      OscParams_Atm[5] = RandVal;
+      OscParams_Beam_woYe[5] = RandVal;
+      OscParams_Beam_wYe[5] = RandVal;
 
       auto t1_single = high_resolution_clock::now();
-      if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
-      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe);
-      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
-        Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
+      if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
+      } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+        Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
       } else {
         std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
         std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/OscProbCalcerComparison.cpp
+++ b/Apps/OscProbCalcerComparison.cpp
@@ -34,6 +34,10 @@ int main() {
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,10.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
 
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+
   std::cout << "========================================================" << std::endl;
   std::cout << "Starting setup in executable" << std::endl;
 
@@ -89,12 +93,12 @@ int main() {
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
     std::cout << "Creating probability from:" << Oscillators[iOsc]->ReturnImplementationName() << std::endl;
     
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/OscProbCalcerComparison.cpp
+++ b/Apps/OscProbCalcerComparison.cpp
@@ -31,36 +31,6 @@ int main() {
   
   //============================================================================================================
   
-  std::vector<FLOAT_T> OscParams_Atm(8);
-  OscParams_Atm[0] = 3.07e-1;
-  OscParams_Atm[1] = 5.28e-1;
-  OscParams_Atm[2] = 2.18e-2;
-  OscParams_Atm[3] = 7.53e-5;
-  OscParams_Atm[4] = 2.509e-3;
-  OscParams_Atm[5] = -1.601;
-  OscParams_Atm[6] = 25.0;
-
-  std::vector<FLOAT_T> OscParams_Beam_woYe(8);
-  OscParams_Beam_woYe[0] = 3.07e-1;
-  OscParams_Beam_woYe[1] = 5.28e-1;
-  OscParams_Beam_woYe[2] = 2.18e-2;
-  OscParams_Beam_woYe[3] = 7.53e-5;
-  OscParams_Beam_woYe[4] = 2.509e-3;
-  OscParams_Beam_woYe[5] = -1.601;
-  OscParams_Beam_woYe[6] = 250.0;
-  OscParams_Beam_woYe[7] = 2.6;
-
-  std::vector<FLOAT_T> OscParams_Beam_wYe(9);
-  OscParams_Beam_wYe[0] = 3.07e-1;
-  OscParams_Beam_wYe[1] = 5.28e-1;
-  OscParams_Beam_wYe[2] = 2.18e-2;
-  OscParams_Beam_wYe[3] = 7.53e-5;
-  OscParams_Beam_wYe[4] = 2.509e-3;
-  OscParams_Beam_wYe[5] = -1.601;
-  OscParams_Beam_wYe[6] = 250.0;
-  OscParams_Beam_wYe[7] = 2.6;
-  OscParams_Beam_wYe[8] = 0.5;
-  
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,10.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
 
@@ -68,34 +38,12 @@ int main() {
   std::cout << "Starting setup in executable" << std::endl;
 
   std::vector<OscillatorBase*> Oscillators;
-  std::vector<std::string> ConfigNames;
-
   OscillatorFactory* OscFactory = new OscillatorFactory();
   OscillatorBase* Oscillator;
 
-#if UseProb3ppLinear == 1
-  ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
-#endif
-
-#if UseCUDAProb3 == 1
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3.yaml");
-#endif
-
-#if UseCUDAProb3Linear == 1
-  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3Linear.yaml");
-#endif
-
-#if UseProbGPULinear == 1
-  ConfigNames.push_back("./Configs/Unbinned_ProbGPULinear.yaml");
-#endif
-
-#if UseNuFASTLinear == 1
-  ConfigNames.push_back("./Configs/Unbinned_NuFASTLinear.yaml");
-#endif
-
-  //Alternative option to show how all information can be held in a single YAML file rather than using a preset
-  //ConfigNames.push_back("./Configs/CUDAProb3_Binned-SelfContainedFile.yaml");
-
+  //Get the standard set of config names
+  std::vector<std::string> ConfigNames = ReturnKnownConfigs();
+ 
   for (size_t iConfig=0;iConfig<ConfigNames.size();iConfig++) {
     std::cout << "========================================================" << std::endl;
     std::cout << "Initialising " << ConfigNames[iConfig] << std::endl;
@@ -141,12 +89,12 @@ int main() {
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
     std::cout << "Creating probability from:" << Oscillators[iOsc]->ReturnImplementationName() << std::endl;
     
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;
@@ -162,6 +110,8 @@ int main() {
       }
     }
   }
+
+  std::cout << "Created probability array.." << std::endl;
 
   std::vector< std::vector<TGraph*> > Probabilities(Oscillators.size());
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {

--- a/Apps/SingleOscProbCalcer.cpp
+++ b/Apps/SingleOscProbCalcer.cpp
@@ -20,36 +20,6 @@ int main(int argc, char **argv) {
   std::string OscProbCalcerConfigname = argv[1];
   
   bool PrintWeights = false;
-
-  std::vector<FLOAT_T> OscParams_Atm(8);
-  OscParams_Atm[0] = 3.07e-1;
-  OscParams_Atm[1] = 5.28e-1;
-  OscParams_Atm[2] = 2.18e-2;
-  OscParams_Atm[3] = 7.53e-5;
-  OscParams_Atm[4] = 2.509e-3;
-  OscParams_Atm[5] = -1.601;
-  OscParams_Atm[6] = 25.0;
-
-  std::vector<FLOAT_T> OscParams_Beam_woYe(8);
-  OscParams_Beam_woYe[0] = 3.07e-1;
-  OscParams_Beam_woYe[1] = 5.28e-1;
-  OscParams_Beam_woYe[2] = 2.18e-2;
-  OscParams_Beam_woYe[3] = 7.53e-5;
-  OscParams_Beam_woYe[4] = 2.509e-3;
-  OscParams_Beam_woYe[5] = -1.601;
-  OscParams_Beam_woYe[6] = 250.0;
-  OscParams_Beam_woYe[7] = 2.6;
-
-  std::vector<FLOAT_T> OscParams_Beam_wYe(9);
-  OscParams_Beam_wYe[0] = 3.07e-1;
-  OscParams_Beam_wYe[1] = 5.28e-1;
-  OscParams_Beam_wYe[2] = 2.18e-2;
-  OscParams_Beam_wYe[3] = 7.53e-5;
-  OscParams_Beam_wYe[4] = 2.509e-3;
-  OscParams_Beam_wYe[5] = -1.601;
-  OscParams_Beam_wYe[6] = 250.0;
-  OscParams_Beam_wYe[7] = 2.6;
-  OscParams_Beam_wYe[8] = 0.5;
   
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
@@ -80,12 +50,12 @@ int main(int argc, char **argv) {
 
   // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
   // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-  if (Calcer->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
-    Calcer->Reweight(OscParams_Beam_woYe);
-  } else if (Calcer->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
-    Calcer->Reweight(OscParams_Beam_wYe); 
-  } else if (Calcer->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-    Calcer->Reweight(OscParams_Atm);
+  if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
+    Calcer->Reweight(NuOscillator::OscParams_Beam_woYe);
+  } else if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
+    Calcer->Reweight(NuOscillator::OscParams_Beam_wYe); 
+  } else if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
+    Calcer->Reweight(NuOscillator::OscParams_Atm);
   } else {
     std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
     std::cerr << "Oscillator->ReturnNOscParams():" << Calcer->ReturnNOscParams() << std::endl;

--- a/Apps/SingleOscProbCalcer.cpp
+++ b/Apps/SingleOscProbCalcer.cpp
@@ -24,6 +24,10 @@ int main(int argc, char **argv) {
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
 
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+  
   std::cout << "========================================================" << std::endl;
   std::cout << "Starting setup in executable" << std::endl;
 
@@ -50,12 +54,12 @@ int main(int argc, char **argv) {
 
   // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
   // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-  if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
-    Calcer->Reweight(NuOscillator::OscParams_Beam_woYe);
-  } else if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
-    Calcer->Reweight(NuOscillator::OscParams_Beam_wYe); 
-  } else if (Calcer->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
-    Calcer->Reweight(NuOscillator::OscParams_Atm);
+  if (Calcer->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+    Calcer->Reweight(OscParams_Beam_woYe);
+  } else if (Calcer->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+    Calcer->Reweight(OscParams_Beam_wYe); 
+  } else if (Calcer->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+    Calcer->Reweight(OscParams_Atm);
   } else {
     std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
     std::cerr << "Oscillator->ReturnNOscParams():" << Calcer->ReturnNOscParams() << std::endl;

--- a/Apps/SingleOscillator.cpp
+++ b/Apps/SingleOscillator.cpp
@@ -23,6 +23,10 @@ int main(int argc, char **argv) {
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
 
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+
   std::cout << "========================================================" << std::endl;
   std::cout << "Starting setup in executable" << std::endl;
 
@@ -68,12 +72,12 @@ int main(int argc, char **argv) {
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
     // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
     // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe); 
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe); 
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Apps/SingleOscillator.cpp
+++ b/Apps/SingleOscillator.cpp
@@ -20,25 +20,6 @@ int main(int argc, char **argv) {
   
   bool PrintWeights = true;
 
-  std::vector<FLOAT_T> OscParams_Atm(7);
-  OscParams_Atm[0] = 3.07e-1;
-  OscParams_Atm[1] = 5.28e-1;
-  OscParams_Atm[2] = 2.18e-2;
-  OscParams_Atm[3] = 7.53e-5;
-  OscParams_Atm[4] = 2.509e-3;
-  OscParams_Atm[5] = -1.601;
-  OscParams_Atm[6] = 25.0;
-
-  std::vector<FLOAT_T> OscParams_Beam(8);
-  OscParams_Beam[0] = 3.07e-1;
-  OscParams_Beam[1] = 5.28e-1;
-  OscParams_Beam[2] = 2.18e-2;
-  OscParams_Beam[3] = 7.53e-5;
-  OscParams_Beam[4] = 2.509e-3;
-  OscParams_Beam[5] = -1.601;
-  OscParams_Beam[6] = 250.0;
-  OscParams_Beam[7] = 2.6;
-
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
 
@@ -87,10 +68,12 @@ int main(int argc, char **argv) {
   for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
     // These don't have to be explicilty beam or atmospheric specific, all they have to be is equal to the number of oscillation parameters expected by the implementation
     // If you have some NSO calculater, then it will work providing the length of the vector of oscillation parameters is equal to the number of expected oscillation parameters
-    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam); 
-    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
-      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Beam_wYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Beam_wYe); 
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)NuOscillator::OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(NuOscillator::OscParams_Atm);
     } else {
       std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
       std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;

--- a/Constants/OscillatorConstants.h
+++ b/Constants/OscillatorConstants.h
@@ -56,18 +56,22 @@ namespace NuOscillator
     FLOAT_T CosineZ;
     FLOAT_T Probability;
   };
-
-#ifndef PARAMS_DEFINED
-#define PARAMS_DEFINED
-  static std::vector<FLOAT_T> OscParams_Atm = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,25.0};
-  static std::vector<FLOAT_T> OscParams_Beam_woYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6};
-  static std::vector<FLOAT_T> OscParams_Beam_wYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6,0.5};
-#else
-  extern static std::vector<FLOAT_T> OscParams_Atm;
-  extern static std::vector<FLOAT_T> OscParams_Beam_woYe;
-  extern static std::vector<FLOAT_T> OscParams_Beam_wYe;
-#endif
   
+}
+
+inline std::vector<FLOAT_T> ReturnOscParams_Atm() {
+  std::vector<FLOAT_T> OscParams_Atm = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,25.0};
+  return OscParams_Atm;
+}
+
+inline std::vector<FLOAT_T> ReturnOscParams_Beam_woYe() {
+  std::vector<FLOAT_T> OscParams_Beam_woYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6};
+  return OscParams_Beam_woYe;
+}
+
+inline std::vector<FLOAT_T> ReturnOscParams_Beam_wYe() {
+  std::vector<FLOAT_T> OscParams_Beam_wYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6,0.5};
+  return OscParams_Beam_wYe;
 }
 
 /**

--- a/Constants/OscillatorConstants.h
+++ b/Constants/OscillatorConstants.h
@@ -56,6 +56,49 @@ namespace NuOscillator
     FLOAT_T CosineZ;
     FLOAT_T Probability;
   };
+
+#ifndef PARAMS_DEFINED
+#define PARAMS_DEFINED
+  static std::vector<FLOAT_T> OscParams_Atm = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,25.0};
+  static std::vector<FLOAT_T> OscParams_Beam_woYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6};
+  static std::vector<FLOAT_T> OscParams_Beam_wYe = {3.07e-1,5.28e-1,2.18e-2,7.53e-5,2.509e-3,-1.601,250.0,2.6,0.5};
+#else
+  extern static std::vector<FLOAT_T> OscParams_Atm;
+  extern static std::vector<FLOAT_T> OscParams_Beam_woYe;
+  extern static std::vector<FLOAT_T> OscParams_Beam_wYe;
+#endif
+  
+}
+
+/**
+ * @brief Return vector of all config names for each oscillation engine which has been enabled
+ *
+ * @return Vector of paths to config files
+ */
+inline std::vector<std::string> ReturnKnownConfigs() {
+  std::vector<std::string> ConfigNames;
+
+#if UseCUDAProb3 == 1
+  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3.yaml");
+#endif
+
+#if UseCUDAProb3Linear == 1
+  ConfigNames.push_back("./Configs/Unbinned_CUDAProb3Linear.yaml");
+#endif
+
+#if UseProbGPULinear == 1
+  ConfigNames.push_back("./Configs/Unbinned_ProbGPULinear.yaml");
+#endif
+
+#if UseProb3ppLinear == 1
+  ConfigNames.push_back("./Configs/Unbinned_Prob3ppLinear.yaml");
+#endif
+
+#if UseNuFASTLinear == 1
+  ConfigNames.push_back("./Configs/Unbinned_NuFASTLinear.yaml");
+#endif  
+
+  return ConfigNames;
 }
 
 /**


### PR DESCRIPTION
# Pull request description:
Move repeatedly defined constants and config vectors into the constants structure so they are only defined in one place. Addresses issue https://github.com/dbarrow257/NuOscillator/issues/25

## Changes or fixes:


## Examples:
