### PR TITLE
Default Cmake settings

### DIFF
--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -37,7 +37,7 @@ jobs:
         git checkout ${{ github.head_ref }}
         mkdir build
         cd build
-        cmake ../ -DUseGPU=0 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0
+        cmake ../ -DUseGPU=0 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=0 -DUseNuFASTLinear=1 -DUseProbGPULinear=0
 
     - name: Build NuOscillator
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,13 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
-if(NOT DEFINED UseGPU)
-    message(FATAL_ERROR "UseGPU is not defined, add -DUseGPU=<1/0>")
-endif()
+#KS: Store some handy cmake functions
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/NuOscillatorUtils.cmake)
 
-set(NUOSCILLATOR_VERSION 0.0)
+# By default GPU is off
+DefineEnabledRequiredSwitch(UseGPU 0)
+
+set(NUOSCILLATOR_VERSION 1.0)
 
 if(${UseGPU} EQUAL 0)
     project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX)
@@ -37,16 +39,28 @@ endif()
 #Custom variable sanitisation
 add_library(NuOscillatorCompilerOptions INTERFACE)
 
+DefineEnabledRequiredSwitch(UseMultithreading 1)
+DefineEnabledRequiredSwitch(UseDoubles 1)
+
+DefineEnabledRequiredSwitch(UseCUDAProb3 0)
+DefineEnabledRequiredSwitch(UseCUDAProb3Linear 0)
+DefineEnabledRequiredSwitch(UseProb3ppLinear 0)
+DefineEnabledRequiredSwitch(UseProbGPULinear 0)
+DefineEnabledRequiredSwitch(UseNuFASTLinear 1)
+
+LIST(APPEND ALL_Engines
+  CUDAProb3
+  CUDAProb3Linear
+  Prob3ppLinear
+  ProbGPULinear
+  NuFASTLinear
+  )
 message(STATUS "NuOscillator Features: ")
-foreach(VAR UseGPU UseMultithreading UseDoubles UseCUDAProb3 UseCUDAProb3Linear UseProb3ppLinear UseProbGPULinear UseNuFASTLinear)
-	    if(NOT DEFINED ${VAR})
-	    	   message(FATAL_ERROR "${VAR} not defined")
-	    endif()
-	    message(STATUS "\t${VAR}: ${${VAR}}")
-endforeach(VAR)
+foreach(f ${ALL_Engines})
+  message(STATUS "     ${f}: ${Use${f}}")
+endforeach()
 
 message(STATUS "Required variables being used:")
-
 if(${UseGPU} EQUAL 1)
 	message(STATUS "\tUsing GPU")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/NuOscillatorUtils.cmake)
 # By default GPU is off
 DefineEnabledRequiredSwitch(UseGPU 0)
 
-set(NUOSCILLATOR_VERSION 1.0)
+set(NUOSCILLATOR_VERSION 1.0.0)
 
 if(${UseGPU} EQUAL 0)
     project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX)
@@ -39,6 +39,20 @@ endif()
 #Custom variable sanitisation
 add_library(NuOscillatorCompilerOptions INTERFACE)
 
+# download CPM.cmake
+file(
+  DOWNLOAD
+  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.8/CPM.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
+)
+include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
+CPMFindPackage(
+      NAME CMakeModules
+      GIT_TAG stable
+      GITHUB_REPOSITORY NuHepMC/CMakeModules
+      DOWNLOAD_ONLY
+  )
+
 DefineEnabledRequiredSwitch(UseMultithreading 1)
 DefineEnabledRequiredSwitch(UseDoubles 1)
 
@@ -55,36 +69,36 @@ LIST(APPEND ALL_Engines
   ProbGPULinear
   NuFASTLinear
   )
-message(STATUS "NuOscillator Features: ")
+cmessage(STATUS "NuOscillator Features: ")
 foreach(f ${ALL_Engines})
-  message(STATUS "     ${f}: ${Use${f}}")
+  cmessage(STATUS "     ${f}: ${Use${f}}")
 endforeach()
 
-message(STATUS "Required variables being used:")
+cmessage(STATUS "Required variables being used:")
 if(${UseGPU} EQUAL 1)
-	message(STATUS "\tUsing GPU")
+    cmessage(STATUS "\tUsing GPU")
 else()
-	message(STATUS "\tNot using GPU")
+    cmessage(STATUS "\tNot using GPU")
 
-	if(${UseProbGPULinear} EQUAL 1)
-		message(FATAL_ERROR "ProbGPULinear calculator can only be used when using GPU")
-	endif()
+    if(${UseProbGPULinear} EQUAL 1)
+        cmessage(FATAL_ERROR "ProbGPULinear calculator can only be used when using GPU")
+    endif()
 endif()
 
 if(${UseMultithreading} EQUAL 1)
-    message(STATUS "\tUsing Multithreading with nThreads=$ENV{OMP_NUM_THREADS}")
+    cmessage(STATUS "\tUsing Multithreading with nThreads=$ENV{OMP_NUM_THREADS}")
 else()
-    message(STATUS "\tNot using Multithreading")
+    cmessage(STATUS "\tNot using Multithreading")
 endif()
 
 if(${UseDoubles} EQUAL 1)
-    message(STATUS "\tUsing FLOAT_T=double")
+    cmessage(STATUS "\tUsing FLOAT_T=double")
 else()
-    message(STATUS "\tUsing FLOAT_T=float")
+    cmessage(STATUS "\tUsing FLOAT_T=float")
 endif()
 
 if(${UseCUDAProb3} EQUAL 1 AND ${UseCUDAProb3Linear} EQUAL 1)
-    message(FATAL_ERROR "CUDAProb3 and CUDAProb3Linear and not able to be built at the same time")
+    cmessage(FATAL_ERROR "CUDAProb3 and CUDAProb3Linear and not able to be built at the same time")
 endif()
 
 if(${UseMultithreading} EQUAL 1)
@@ -98,7 +112,7 @@ endif()
 
 separate_arguments(NuOscillator_Compiler_Flags)
 
-message(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
+cmessage(STATUS "Set compiler options: ${NuOscillator_Compiler_Flags}")
 add_compile_options(${NuOscillator_Compiler_Flags})
 
 if(${UseGPU} EQUAL 1)
@@ -121,20 +135,11 @@ if(${UseGPU} EQUAL 1)
 	string(REPLACE " " ";" CMAKE_CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
 	endif()
 
-    message(STATUS "Set CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES_STRING}")
+    cmessage(STATUS "Set CUDA ARCHITECTURES options: ${CMAKE_CUDA_ARCHITECTURES_STRING}")
 endif()
 
 #================================================================================================
 #Setup Deps
-
-# download CPM.cmake
-file(
-  DOWNLOAD
-  https://github.com/cpm-cmake/CPM.cmake/releases/download/v0.38.8/CPM.cmake
-  ${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake
-)
-include(${CMAKE_CURRENT_BINARY_DIR}/cmake/CPM.cmake)
-
 CPMAddPackage(
     NAME yaml-cpp
     VERSION 0.7.0
@@ -144,12 +149,7 @@ CPMAddPackage(
       "YAML_BUILD_SHARED_LIBS ON"
 )
 
-CPMFindPackage(
-      NAME CMakeModules
-      GIT_TAG stable
-      GITHUB_REPOSITORY NuHepMC/CMakeModules
-      DOWNLOAD_ONLY
-  )
+
 include(${CMakeModules_SOURCE_DIR}/NuHepMCModules.cmake)
 
 include(ROOT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,16 @@ DefineEnabledRequiredSwitch(UseCUDAProb3 0)
 DefineEnabledRequiredSwitch(UseCUDAProb3Linear 0)
 DefineEnabledRequiredSwitch(UseProb3ppLinear 0)
 DefineEnabledRequiredSwitch(UseProbGPULinear 0)
-DefineEnabledRequiredSwitch(UseNuFASTLinear 1)
+DefineEnabledRequiredSwitch(UseNuFASTLinear 0)
+
+# KS: NuFastLinear by default
+if(UseCUDAProb3       EQUAL 0 AND
+   UseCUDAProb3Linear EQUAL 0 AND
+   UseProb3ppLinear   EQUAL 0 AND
+   UseProbGPULinear   EQUAL 0 AND
+   UseNuFASTLinear    EQUAL 0)
+    set(UseNuFASTLinear 1)
+endif()
 
 LIST(APPEND ALL_Engines
   CUDAProb3

--- a/cmake/Modules/NuOscillatorUtils.cmake
+++ b/cmake/Modules/NuOscillatorUtils.cmake
@@ -1,0 +1,12 @@
+#KS: Inspired by Nuisance code
+if(NOT COMMAND DefineEnabledRequiredSwitch)
+  function(DefineEnabledRequiredSwitch VARNAME DEFAULTVALUE)
+    if(NOT DEFINED ${VARNAME} OR "${${VARNAME}}x" STREQUAL "x")
+      set(${VARNAME} ${DEFAULTVALUE} PARENT_SCOPE)
+      set(${VARNAME} ${DEFAULTVALUE})
+    else()
+      set(${VARNAME}_REQUIRED ${${VARNAME}} PARENT_SCOPE)
+      set(${VARNAME}_REQUIRED ${${VARNAME}})
+    endif()
+  endfunction()
+endif()


### PR DESCRIPTION
# Pull request description:
Some minor tweaks to cmake. If user have no clue and just call cmake.. it will prepare NuOsicllator with just NuFast as default


## Changes or fixes:
- Now there are default values set. So no longer there is need to loop over to make sure everything is set.
- Get NuHepMC Tools eariler to use cmessage
- Bumped version...

## Examples:
<img width="707" alt="blarb" src="https://github.com/user-attachments/assets/93f10c0b-68ef-4d25-9f7d-ea15fa02b81f">
