### PR TITLE
Avoid potetnial overflow

### DIFF
--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -146,6 +146,6 @@ int OscProbCalcerCUDAProb3::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanI
 }
 
 long OscProbCalcerCUDAProb3::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
@@ -146,6 +146,6 @@ int OscProbCalcerCUDAProb3Linear::ReturnWeightArrayIndex(int NuTypeIndex, int Os
 }
 
 long OscProbCalcerCUDAProb3Linear::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -88,7 +88,7 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
 	  std::cout << "iOscProb:" << iOscProb << " iNuType:" << iNuType << " iOscChannel:" << iOscChannel << " IndexToFill:" << IndexToFill << " fWeightArray[IndexToFill+iOscProb]:" << Weight << std::endl;
 	  throw std::runtime_error("Invalid probability");
 	}
-	
+
 	fWeightArray[IndexToFill+iOscProb] = Weight;
       }
       
@@ -103,6 +103,6 @@ int OscProbCalcerNuFASTLinear::ReturnWeightArrayIndex(int NuTypeIndex, int OscCh
 }
 
 long OscProbCalcerNuFASTLinear::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }

--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -468,7 +468,7 @@ int OscProbCalcerOscProb::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanInd
 }
 
 long OscProbCalcerOscProb::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }
 

--- a/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_Prob3ppLinear.cpp
@@ -60,6 +60,6 @@ int OscProbCalcerProb3ppLinear::ReturnWeightArrayIndex(int NuTypeIndex, int OscC
 }
 
 long OscProbCalcerProb3ppLinear::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }

--- a/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_ProbGPULinear.cpp
@@ -61,6 +61,6 @@ int OscProbCalcerProbGPULinear::ReturnWeightArrayIndex(int NuTypeIndex, int OscC
 }
 
 long OscProbCalcerProbGPULinear::DefineWeightArraySize() {
-  long nCalculationPoints = fNEnergyPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNOscillationChannels * fNNeutrinoTypes;
   return nCalculationPoints;
 }


### PR DESCRIPTION
# Pull request description:
Multiplication result may overflow 'int' before it is converted to 'long'. Therafore let's do static cast to long and then proceed to multiplcation

## Changes or fixes:


## Examples:
