### PR TITLE
perf: Use ProbMatrix to parallelize computations

### DIFF
--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -1,7 +1,5 @@
 #include "OscProbCalcer_OscProb.h"
 
-#include "TMath.h"
-
 OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBase(Config_)
 {
   //=======
@@ -35,7 +33,16 @@ OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBa
 
   fOscType = PMNS_StrToInt(OscMatrix);
   fNOscParams = GetNOscParams(fOscType);
-  
+
+  fMaxGenFlavour = 1;
+  fMaxDetFlavour = 1;
+  for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
+    int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour;
+    int dflv = fOscillationChannels[iOscChannel].DetectedFlavour;
+    if(gflv>fMaxGenFlavour) fMaxGenFlavour = gflv;
+    if(dflv>fMaxDetFlavour) fMaxDetFlavour = dflv;
+  }
+
   std::cout << "PMNS Type : " << fOscType << std::endl;
   std::cout << "Number of parameters : " << fNOscParams << std::endl;
   std::cout << "PREM Model : " << premfile << std::endl;
@@ -46,7 +53,7 @@ OscProbCalcerOscProb::~OscProbCalcerOscProb() {
 }
 
 void OscProbCalcerOscProb::SetupPropagator() {
-  
+
   PremModel = OscProb::PremModel(premfile);
 
 }
@@ -58,7 +65,7 @@ void OscProbCalcerOscProb::CalculateProbabilities(const std::vector<FLOAT_T>& Os
   PremModel.SetDetPos(det_radius);
 
   switch(fOscType) {
-    case kFast: 
+    case kFast:
       CalcProbPMNS_Fast(OscParams);
       break;
 
@@ -77,7 +84,7 @@ void OscProbCalcerOscProb::CalculateProbabilities(const std::vector<FLOAT_T>& Os
     case kDecay:
       CalcProbPMNS_Decay(OscParams);
       break;
-    
+
     case kDeco:
       CalcProbPMNS_Deco(OscParams);
       break;
@@ -107,36 +114,30 @@ void OscProbCalcerOscProb::CalculateProbabilities(const std::vector<FLOAT_T>& Os
   }
 }
 
-void OscProbCalcerOscProb::CalcProbPMNS_Fast(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
+void OscProbCalcerOscProb::CalcProbPMNS(OscProb::PMNS_Base* myPMNS) {
 
-  OscProb::PMNS_Fast myPMNS;
+  for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
 
-  SetPMNSParams_Fast(&myPMNS, OscParams);
-  
+    myPMNS->SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
+    for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
 
-    cosZ = fCosineZArray[iCosineZ];
+      PremModel.FillPath(fCosineZArray[iCosineZ]);
 
-    PremModel.FillPath(cosZ);
+      myPMNS->SetPath(PremModel.GetNuPath());
 
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
+      for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
 
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
+        OscProb::matrixD probMatrix = myPMNS->ProbMatrix(fMaxGenFlavour,
+                                                         fMaxDetFlavour,
+                                                         fEnergyArray[iEnergy]);
 
         for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
+
+          int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour-1;
+          int dflv = fOscillationChannels[iOscChannel].DetectedFlavour-1;
+          double weight = probMatrix[gflv][dflv];
+          int index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
 
           fWeightArray[index] = weight;
 
@@ -145,377 +146,128 @@ void OscProbCalcerOscProb::CalcProbPMNS_Fast(const std::vector<FLOAT_T>& OscPara
       }
     }
   }
+
+}
+
+void OscProbCalcerOscProb::CalcProbPMNS_Fast(const std::vector<FLOAT_T>& OscParams) {
+
+  OscProb::PMNS_Fast myPMNS;
+  SetPMNSParams(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_Sterile(const std::vector<FLOAT_T>& OscParams, int neutrino_number) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_Sterile myPMNS(neutrino_number);
-
   SetPMNSParams_Sterile(&myPMNS, OscParams);
-  
+
   std::cout << "Proba with PMNS Sterile and " << neutrino_number << " neutrinos" << std::endl;
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
+  return CalcProbPMNS(&myPMNS);
 
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_Decay(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_Decay myPMNS;
-
   SetPMNSParams_Decay(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_Deco(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_Deco myPMNS;
-
   SetPMNSParams_Deco(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_NSI(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_NSI myPMNS;
-
   SetPMNSParams_NSI(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_SNSI(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_SNSI myPMNS;
-
   SetPMNSParams_SNSI(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_Iter(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_Iter myPMNS;
-
   SetPMNSParams_Iter(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_NUNM(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_NUNM myPMNS;
-
   SetPMNSParams_NUNM(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
 void OscProbCalcerOscProb::CalcProbPMNS_LIV(const std::vector<FLOAT_T>& OscParams) {
-  double energy, cosZ;
-  double weight;
-  int index;
 
   OscProb::PMNS_LIV myPMNS;
-
   SetPMNSParams_LIV(&myPMNS, OscParams);
+  return CalcProbPMNS(&myPMNS);
 
-  for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
-
-    cosZ = fCosineZArray[iCosineZ];
-
-    PremModel.FillPath(cosZ);
-
-    myPMNS.SetPath(PremModel.GetNuPath());
-    
-    for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
-
-      energy = fEnergyArray[iEnergy];
-
-      for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
-
-        myPMNS.SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
-
-        for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
-          
-          weight = myPMNS.Prob(fOscillationChannels[iOscChannel].GeneratedFlavour-1, fOscillationChannels[iOscChannel].DetectedFlavour-1, energy);
-          index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
-
-          fWeightArray[index] = weight;
-
-        }
-
-      }
-    }
-  }
 }
 
-int OscProbCalcerOscProb::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex) {
-  int IndexToReturn = NuTypeIndex*fNOscillationChannels*fNCosineZPoints*fNEnergyPoints + OscChanIndex*fNCosineZPoints*fNEnergyPoints + CosineZIndex*fNEnergyPoints + EnergyIndex;
+int OscProbCalcerOscProb::ReturnWeightArrayIndex(int NuTypeIndex,
+                                                 int OscChanIndex,
+                                                 int EnergyIndex,
+                                                 int CosineZIndex) {
+  int IndexToReturn = ((NuTypeIndex *  fNOscillationChannels +
+                        OscChanIndex) * fNCosineZPoints +
+                        CosineZIndex) * fNEnergyPoints +
+                        EnergyIndex;
   return IndexToReturn;
 }
 
 long OscProbCalcerOscProb::DefineWeightArraySize() {
-  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) *
+                            fNCosineZPoints *
+                            fNOscillationChannels *
+                            fNNeutrinoTypes;
   return nCalculationPoints;
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_Fast(OscProb::PMNS_Fast *Fast, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
+void OscProbCalcerOscProb::SetPMNSParams(OscProb::PMNS_Base* pmns,
+                                         const std::vector<FLOAT_T>& OscParams) {
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
+  double th12 = asin(sqrt(OscParams[kTH12]));
+  double th13 = asin(sqrt(OscParams[kTH13]));
+  double th23 = asin(sqrt(OscParams[kTH23]));
+  double dcp  = OscParams[kDCP];
+  double dm21 = OscParams[kDM12];
 
   //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  double dm31 = OscParams[kDM23] + OscParams[kDM12]; // eV^2
 
   // Set PMNS parameters
-  Fast->SetDm(2, dm21);
-  Fast->SetDm(3, dm31);
-  Fast->SetAngle(1,2, th12);
-  Fast->SetAngle(1,3, th13);
-  Fast->SetAngle(2,3, th23);
-  Fast->SetDelta(1,3, dcp);
+  pmns->SetDm(2, dm21);
+  pmns->SetDm(3, dm31);
+  pmns->SetAngle(1,2, th12);
+  pmns->SetAngle(1,3, th13);
+  pmns->SetAngle(2,3, th23);
+  pmns->SetDelta(1,3, dcp);
+
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_Sterile(OscProb::PMNS_Sterile *Sterile, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
-
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
-
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
-
-  // Set PMNS parameters for standard oscillation
-  Sterile->SetDm(2, dm21);
-  Sterile->SetDm(3, dm31);
-  Sterile->SetAngle(1,2, th12);
-  Sterile->SetAngle(1,3, th13);
-  Sterile->SetAngle(2,3, th23);
-  Sterile->SetDelta(1,3, dcp);
+void OscProbCalcerOscProb::SetPMNSParams_Sterile(OscProb::PMNS_Sterile* Sterile,
+                                                 const std::vector<FLOAT_T>& OscParams) {
+  SetPMNSParams(Sterile, OscParams);
 
   //Set PMNS parameters for first sterile state
   Sterile->SetDm(4, OscParams[kDM14]);
@@ -553,168 +305,77 @@ void OscProbCalcerOscProb::SetPMNSParams_Sterile(OscProb::PMNS_Sterile *Sterile,
 
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_Decay(OscProb::PMNS_Decay *Decay, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
-  double alpha2, alpha3;
+void OscProbCalcerOscProb::SetPMNSParams_Decay(OscProb::PMNS_Decay* Decay,
+                                               const std::vector<FLOAT_T>& OscParams) {
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
-  alpha2 = OscParams[kAlpha2];
-  alpha3 = OscParams[kAlpha3];
+  SetPMNSParams(Decay, OscParams);
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  // Set Decay parameters
+  Decay->SetAlpha2(OscParams[kAlpha2]);
+  Decay->SetAlpha3(OscParams[kAlpha3]);
 
-  // Set PMNS parameters
-  Decay->SetDm(2, dm21);
-  Decay->SetDm(3, dm31);
-  Decay->SetAngle(1,2, th12);
-  Decay->SetAngle(1,3, th13);
-  Decay->SetAngle(2,3, th23);
-  Decay->SetDelta(1,3, dcp);
-  Decay->SetAlpha2(alpha2);
-  Decay->SetAlpha3(alpha3);
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_Deco(OscProb::PMNS_Deco *Deco, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
-  double gamma21, gamma31;
-  double deco_angle, power;
+void OscProbCalcerOscProb::SetPMNSParams_Deco(OscProb::PMNS_Deco* Deco,
+                                              const std::vector<FLOAT_T>& OscParams) {
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
-  gamma21 = OscParams[kGamma21];
-  gamma31 = OscParams[kGamma31];
-  deco_angle = OscParams[kDecoAngle];
-  power = OscParams[kPower];
+  SetPMNSParams(Deco, OscParams);
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  // Set Deco parameters
+  Deco->SetGamma(2, OscParams[kGamma21]);
+  Deco->SetGamma(3, OscParams[kGamma31]);
+  Deco->SetDecoAngle(OscParams[kDecoAngle]);
+  Deco->SetPower(OscParams[kPower]);
 
-  // Set PMNS parameters
-  Deco->SetDm(2, dm21);
-  Deco->SetDm(3, dm31);
-  Deco->SetAngle(1,2, th12);
-  Deco->SetAngle(1,3, th13);
-  Deco->SetAngle(2,3, th23);
-  Deco->SetDelta(1,3, dcp);
-  Deco->SetGamma(2, gamma21);
-  Deco->SetGamma(3, gamma31);
-  Deco->SetDecoAngle(deco_angle);
-  Deco->SetPower(power);
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_NSI(OscProb::PMNS_NSI *NSI, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
+void OscProbCalcerOscProb::SetPMNSParams_NSI(OscProb::PMNS_NSI* NSI,
+                                             const std::vector<FLOAT_T>& OscParams) {
+  SetPMNSParams(NSI, OscParams);
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
+  // Set NSI parameters
+  NSI->SetNSI(OscParams[kEps_ee],
+              OscParams[kEps_emu],
+              OscParams[kEps_etau],
+              OscParams[kEps_mumu],
+              OscParams[kEps_mutau],
+              OscParams[kEps_tautau],
+              OscParams[kDelta_emu],
+              OscParams[kDelta_etau],
+              OscParams[kDelta_mutau]);
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  NSI->SetFermCoup(OscParams[kElecCoup],
+                   OscParams[kUpCoup],
+                   OscParams[kDownCoup]);
 
-  // Set PMNS parameters
-  NSI->SetDm(2, dm21);
-  NSI->SetDm(3, dm31);
-  NSI->SetAngle(1,2, th12);
-  NSI->SetAngle(1,3, th13);
-  NSI->SetAngle(2,3, th23);
-  NSI->SetDelta(1,3, dcp);
-  NSI->SetNSI(OscParams[kEps_ee], OscParams[kEps_emu], OscParams[kEps_etau], OscParams[kEps_mumu], OscParams[kEps_mutau], OscParams[kEps_tautau],
-              OscParams[kDelta_emu], OscParams[kDelta_etau], OscParams[kDelta_mutau]);
-  NSI->SetFermCoup(OscParams[kElecCoup], OscParams[kUpCoup], OscParams[kDownCoup]);
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_SNSI(OscProb::PMNS_SNSI *SNSI, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
+void OscProbCalcerOscProb::SetPMNSParams_SNSI(OscProb::PMNS_SNSI* SNSI,
+                                              const std::vector<FLOAT_T>& OscParams) {
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
+  SetPMNSParams_NSI(SNSI, OscParams);
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
-
-  // Set PMNS parameters
-  SNSI->SetDm(2, dm21);
-  SNSI->SetDm(3, dm31);
-  SNSI->SetAngle(1,2, th12);
-  SNSI->SetAngle(1,3, th13);
-  SNSI->SetAngle(2,3, th23);
-  SNSI->SetDelta(1,3, dcp);
-  SNSI->SetNSI(OscParams[kEps_ee], OscParams[kEps_emu], OscParams[kEps_etau], OscParams[kEps_mumu], OscParams[kEps_mutau], OscParams[kEps_tautau],
-              OscParams[kDelta_emu], OscParams[kDelta_etau], OscParams[kDelta_mutau]);
-  SNSI->SetFermCoup(OscParams[kElecCoup], OscParams[kUpCoup], OscParams[kDownCoup]);
+  // Set SNSI parameters
   SNSI->SetLowestMass(OscParams[kLightMass]);
+
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_Iter(OscProb::PMNS_Iter *Iter, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
-  double prec;
+void OscProbCalcerOscProb::SetPMNSParams_Iter(OscProb::PMNS_Iter* Iter,
+                                              const std::vector<FLOAT_T>& OscParams) {
 
-  prec = OscParams[kPrec];
+  SetPMNSParams(Iter, OscParams);
 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
+  // Set Iter parameters
+  Iter->SetPrec(OscParams[kPrec]);
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
-
-  // Set PMNS parameters
-  Iter->SetDm(2, dm21);
-  Iter->SetDm(3, dm31);
-  Iter->SetAngle(1,2, th12);
-  Iter->SetAngle(1,3, th13);
-  Iter->SetAngle(2,3, th23);
-  Iter->SetDelta(1,3, dcp);
-  Iter->SetPrec(prec);
 }
 
-void OscProbCalcerOscProb::SetPMNSParams_NUNM(OscProb::PMNS_NUNM *NUNM, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
- 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
+void OscProbCalcerOscProb::SetPMNSParams_NUNM(OscProb::PMNS_NUNM* NUNM,
+                                              const std::vector<FLOAT_T>& OscParams) {
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  SetPMNSParams(NUNM, OscParams);
 
   // Set PMNS parameters
-  NUNM->SetDm(2, dm21);
-  NUNM->SetDm(3, dm31);
-  NUNM->SetAngle(1,2, th12);
-  NUNM->SetAngle(1,3, th13);
-  NUNM->SetAngle(2,3, th23);
-  NUNM->SetDelta(1,3, dcp);
   NUNM->SetAlpha_11(OscParams[kAlpha11]);
   NUNM->SetAlpha_22(OscParams[kAlpha22]);
   NUNM->SetAlpha_33(OscParams[kAlpha33]);
@@ -722,30 +383,14 @@ void OscProbCalcerOscProb::SetPMNSParams_NUNM(OscProb::PMNS_NUNM *NUNM, const st
   NUNM->SetAlpha_31(OscParams[kAlpha31], OscParams[kPhi31]);
   NUNM->SetAlpha_32(OscParams[kAlpha32], OscParams[kPhi32]);
   NUNM->SetFracVnc(OscParams[kFracVnc]);
+
 }
 
 void OscProbCalcerOscProb::SetPMNSParams_LIV(OscProb::PMNS_LIV *LIV, const std::vector<FLOAT_T>& OscParams) {
-  double th12, th13, th23;
-  double dm21, dm31;
-  double dcp;
- 
-  th12 = asin(sqrt(OscParams[kTH12]));
-  th13 = asin(sqrt(OscParams[kTH13]));
-  th23 = asin(sqrt(OscParams[kTH23]));
-  dcp = OscParams[kDCP];
-  dm21 = OscParams[kDM12];
 
-  //Need to convert OscParams[kDM23] to kDM31
-  dm31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  SetPMNSParams(LIV, OscParams);
 
-  // Set PMNS parameters
-  LIV->SetDm(2, dm21);
-  LIV->SetDm(3, dm31);
-  LIV->SetAngle(1,2, th12);
-  LIV->SetAngle(1,3, th13);
-  LIV->SetAngle(2,3, th23);
-  LIV->SetDelta(1,3, dcp);
-
+  // Set LIV parameters
   LIV->SetaT(0, 0, 3, OscParams[kaT_ee_3], 0.);
   LIV->SetaT(0, 1, 3, OscParams[kaT_emu_3], OscParams[kDelta_emu_3]);
   LIV->SetaT(0, 2, 3, OscParams[kaT_etau_3], OscParams[kDelta_etau_3]);
@@ -787,10 +432,10 @@ void OscProbCalcerOscProb::SetPMNSParams_LIV(OscProb::PMNS_LIV *LIV, const std::
 int OscProbCalcerOscProb::PMNS_StrToInt(std::string PMNSType) {
   if (PMNSType == "Fast" || PMNSType == "fast") {
     return kFast;
-  } 
+  }
   else if (PMNSType == "Sterile+1" || PMNSType == "Sterile1") {
     return kPMNSSterile1;
-  } 
+  }
   else if (PMNSType == "Sterile+2" || PMNSType == "Sterile2") {
     return kPMNSSterile2;
   }
@@ -822,7 +467,7 @@ int OscProbCalcerOscProb::PMNS_StrToInt(std::string PMNSType) {
     std::cerr << "Invalid PMNS matrix type provided:" << PMNSType << std::endl;
     throw std::runtime_error("Invalid setup");
   }
-  
+
   return -1;
 }
 

--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -1,4 +1,5 @@
 #include "OscProbCalcer_OscProb.h"
+#include <fstream>
 
 OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBase(Config_)
 {
@@ -53,6 +54,9 @@ OscProbCalcerOscProb::~OscProbCalcerOscProb() {
 }
 
 void OscProbCalcerOscProb::SetupPropagator() {
+
+  std::ifstream file(premfile);
+  if(!file) throw std::runtime_error("could not open PREM file " + premfile);
 
   PremModel = OscProb::PremModel(premfile);
 

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -37,7 +37,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @param ConfigName_ File path to config
    */
   OscProbCalcerOscProb(std::string ConfigName_) : OscProbCalcerOscProb(YAML::LoadFile(ConfigName_)) {}
-  
+
   /**
    * @brief Destructor
    */
@@ -48,9 +48,9 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
 
   /**
    * @brief Setup Earth model
-   */  
+   */
   void SetupPropagator() override;
-  
+
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
@@ -59,6 +59,16 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
   void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
+
+  /**
+   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
+   *
+   * Calculator oscillation probabilities with any PMNS object. This function both calculates and stores
+   * the oscillation probabilities in #fWeightArray.
+   *
+   * @param myPMNS The PMNS object to compute
+   */
+  void CalcProbPMNS(OscProb::PMNS_Base* myPMNS);
 
   /**
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
@@ -85,7 +95,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_Decay object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -95,7 +105,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_Deco object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -105,7 +115,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_NSI object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -115,7 +125,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_SNSI object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -125,7 +135,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_Iter object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -135,7 +145,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_NUNM object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -145,7 +155,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
    *
    * Calculator oscillation probabilities with PMNS_LIV object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray. 
+   * the oscillation probabilities in #fWeightArray.
    *
    * @param OscParams The parameter set to calculate oscillation probabilities at
    */
@@ -153,16 +163,16 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
-   * 
-   * @param NuTypeIndex The index in #fNeutrinoTypes (neutrino/antinuetrino) to return the pointer for 
-   * @param OscChanIndex The index in #fOscillationChannels to return the pointer for 
-   * @param EnergyIndex The index in #fEnergyArray to return the pointer for 
-   * @param CosineZIndex The index in #fCosineZArray to return the pointer for 
+   *
+   * @param NuTypeIndex The index in #fNeutrinoTypes (neutrino/antinuetrino) to return the pointer for
+   * @param OscChanIndex The index in #fOscillationChannels to return the pointer for
+   * @param EnergyIndex The index in #fEnergyArray to return the pointer for
+   * @param CosineZIndex The index in #fCosineZArray to return the pointer for
    *
    * @return Index in #fWeightArray which corresponds to the given inputs
    */
   int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1) override;
-  
+
   /**
    * @brief Define the size of fWeightArray
    *
@@ -176,8 +186,8 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   // Functions which help setup implementation specific code
 
   /**
- * @brief Return the PMNS Matrix type corresponding to a particular string 
- * 
+ * @brief Return the PMNS Matrix type corresponding to a particular string
+ *
  * @param PMNSType String to convert to enum value
  *
  * @return Enum value describing the PMNS Matrix to use
@@ -186,7 +196,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
 
   /**
  * @brief Return number of parameters needed for a particular type of PMNS matrix
- * 
+ *
  * @param OscType int value corresponding to type of PMNS matrix
  *
  * @return number of parameters needed for the type of PMNS matrix
@@ -194,100 +204,100 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   int GetNOscParams(int OscType);
 
   /**
- * @brief Set parameters for PMNS_Fast 
- * 
- * @param Fast object of class PMNS_Fast 
+ * @brief Set parameters for PMNS_Base
+ *
+ * @param PMNS object of any class
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_Fast(OscProb::PMNS_Fast *Fast, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams(OscProb::PMNS_Base* pmns, const std::vector<FLOAT_T>& OscParams);
 
   /**
  * @brief Set parameters for PMNS_Sterile with up to 3 additional neutrino states
- * 
+ *
  * @param Sterile object of class PMNS_Sterile
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_Sterile(OscProb::PMNS_Sterile *Sterile, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_Sterile(OscProb::PMNS_Sterile* Sterile, const std::vector<FLOAT_T>& OscParams);
 
    /**
  * @brief Set parameters for PMNS_Decay
- * 
+ *
  * @param Decay object of class PMNS_Decay
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_Decay(OscProb::PMNS_Decay *Decay, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_Decay(OscProb::PMNS_Decay* Decay, const std::vector<FLOAT_T>& OscParams);
 
   /**
  * @brief Set parameters for PMNS_Deco
- * 
+ *
  * @param Deco object of class PMNS_Deco
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_Deco(OscProb::PMNS_Deco *Deco, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_Deco(OscProb::PMNS_Deco* Deco, const std::vector<FLOAT_T>& OscParams);
 
   /**
  * @brief Set parameters for PMNS_NSI
- * 
+ *
  * @param NSI object of class PMNS_NSI
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_NSI(OscProb::PMNS_NSI *NSI, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_NSI(OscProb::PMNS_NSI* NSI, const std::vector<FLOAT_T>& OscParams);
 
    /**
  * @brief Set parameters for PMNS_SNSI
- * 
+ *
  * @param SNSI object of class PMNS_SNSI
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_SNSI(OscProb::PMNS_SNSI *SNSI, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_SNSI(OscProb::PMNS_SNSI* SNSI, const std::vector<FLOAT_T>& OscParams);
 
   /**
- * @brief Set parameters for PMNS_Iter 
- * 
- * @param Iter object of class PMNS_Iter 
+ * @brief Set parameters for PMNS_Iter
+ *
+ * @param Iter object of class PMNS_Iter
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_Iter(OscProb::PMNS_Iter *Iter, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_Iter(OscProb::PMNS_Iter* Iter, const std::vector<FLOAT_T>& OscParams);
 
   /**
  * @brief Set parameters for PMNS_NUNM
- * 
+ *
  * @param NUNM object of class PMNS_NUNM
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_NUNM(OscProb::PMNS_NUNM *NUNM, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_NUNM(OscProb::PMNS_NUNM* NUNM, const std::vector<FLOAT_T>& OscParams);
 
     /**
  * @brief Set parameters for PMNS_LIV
- * 
+ *
  * @param LIV object of class PMNS_LIV
  * @param OscParams  The parameter set to calculate oscillation probabilities at
  *
  * @return Sets relevant parameters for PMNS Matrix
  */
-  void SetPMNSParams_LIV(OscProb::PMNS_LIV *LIV, const std::vector<FLOAT_T>& OscParams);
+  void SetPMNSParams_LIV(OscProb::PMNS_LIV* LIV, const std::vector<FLOAT_T>& OscParams);
 
   // ========================================================================================================================================================================
   // Variables which are needed for implementation specific code
 
   /**
-   * @brief Definition of oscillation parameters which are expected in this ProbGPU implementation. 
+   * @brief Definition of oscillation parameters which are expected in this ProbGPU implementation.
    * Base parameters for standard 3x3 oscillation matrix, works as is for PMNS_Fast class
    * DetDepth is the detector depth and is expected in km
    */
@@ -301,7 +311,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    */
   enum OscParams_Sterile{kTH14=kDCP+1, kTH24=kDCP+2, kTH34=kDCP+3, kDM14=kDCP+4, kDelta14=kDCP+5, kDelta24=kDCP+6,
                          kTH15=kDCP+7, kTH25=kDCP+8, kTH35=kDCP+9, kTH45=kDCP+10, kDM15=kDCP+11, kDelta15=kDCP+12, kDelta25=kDCP+13, kDelta35=kDCP+14,
-                         kTH16=kDCP+15, kTH26=kDCP+16, kTH36=kDCP+17, kTH46=kDCP+18, kTH56=kDCP+19, kDM16=kDCP+20, 
+                         kTH16=kDCP+15, kTH26=kDCP+16, kTH36=kDCP+17, kTH46=kDCP+18, kTH56=kDCP+19, kDM16=kDCP+20,
                          kDelta16=kDCP+21, kDelta26=kDCP+22, kDelta36=kDCP+23, kDelta46=kDCP+24};
 
   /**
@@ -313,7 +323,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
 
     /**
    * @brief Definition of extra oscillation parameters for PMNS_Deco class
-   * kGamma21 decoherence parameter between mass states 1 and 2 
+   * kGamma21 decoherence parameter between mass states 1 and 2
    * kGamma31 decoherence parameter between mass states 3 and 1
    * kDecoAngle decoherence angle
    * kPower power index of decoherence energy dependence
@@ -322,14 +332,14 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
 
    /**
    * @brief Definition of extra oscillation parameters for PMNS_NSI class
-   * kEps quantity reprensenting the intensity of NSI wrt standard matter effects between the different flavours 
-   * kDelta complex phases between the different flavours (non diag elements)
+   * kEps quantity reprensenting the intensity of NSI wrt standard matter effects between the different flavours
+   * kDelta complex phases between the different flavours (non diag elements
    * kElecCoup electron coupling
    * kUpCoup u-quark coupling
    * kDownCoup d-quark coupling
    */
-  enum OscParams_NSI{kEps_ee = kDCP+1, kEps_emu = kDCP+2, kEps_etau = kDCP+3, kEps_mumu = kDCP+4, 
-                     kEps_mutau = kDCP+5, kEps_tautau= kDCP+6, kDelta_emu = kDCP+7, kDelta_etau = kDCP+8, 
+  enum OscParams_NSI{kEps_ee = kDCP+1, kEps_emu = kDCP+2, kEps_etau = kDCP+3, kEps_mumu = kDCP+4,
+                     kEps_mutau = kDCP+5, kEps_tautau= kDCP+6, kDelta_emu = kDCP+7, kDelta_etau = kDCP+8,
                      kDelta_mutau = kDCP+9, kElecCoup = kDCP+10, kUpCoup = kDCP+11, kDownCoup = kDCP+12};
 
   /**
@@ -349,7 +359,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   /**
    * @brief Definition of extra oscillation parameters for PMNS_NUNM class (non unitary neutrino mixing)
    * kAlphaij quantify deviation from unitary wrt standard mixing between states i and j
-   * kPhiij complex phases for non diagonal elements between states i and j 
+   * kPhiij complex phases for non diagonal elements between states i and j
    * kFracVnc fraction of matter potential affecting NC
    */
   enum OscParams_NUNM{kAlpha11 = kDCP+1, kAlpha21 = kDCP+2, kAlpha31 = kDCP+3, kAlpha22 = kDCP+4, kAlpha32 = kDCP+5, kAlpha33 = kDCP+6,
@@ -361,19 +371,19 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kcT_j LIV coefficient of dimension j between 2 neutrino flavors with j = 4, 6 or 8
    * kDelta_j complex phase between 2 neutrino flavors for non diag element with dimension j
    */
-  enum OscParams_LIV{kaT_ee_3 = kDCP+1, kaT_emu_3 = kDCP+2, kaT_etau_3 = kDCP+3, kaT_mumu_3 = kDCP+4, kaT_mutau_3 = kDCP+5, 
+  enum OscParams_LIV{kaT_ee_3 = kDCP+1, kaT_emu_3 = kDCP+2, kaT_etau_3 = kDCP+3, kaT_mumu_3 = kDCP+4, kaT_mutau_3 = kDCP+5,
                      kaT_tautau_3 = kDCP+6, kDelta_emu_3 = kDCP+7, kDelta_etau_3 = kDCP+8, kDelta_mutau_3 = kDCP+9,
-                     kcT_ee_4 = kDCP+10, kcT_emu_4 = kDCP+11, kcT_etau_4 = kDCP+12, kcT_mumu_4 = kDCP+13, kcT_mutau_4 = kDCP+14, 
+                     kcT_ee_4 = kDCP+10, kcT_emu_4 = kDCP+11, kcT_etau_4 = kDCP+12, kcT_mumu_4 = kDCP+13, kcT_mutau_4 = kDCP+14,
                      kcT_tautau_4 = kDCP+15, kDelta_emu_4 = kDCP+16, kDelta_etau_4 = kDCP+17, kDelta_mutau_4 = kDCP+18,
-                     kaT_ee_5 = kDCP+19, kaT_emu_5 = kDCP+20, kaT_etau_5 = kDCP+21, kaT_mumu_5 = kDCP+22, kaT_mutau_5 = kDCP+23, 
+                     kaT_ee_5 = kDCP+19, kaT_emu_5 = kDCP+20, kaT_etau_5 = kDCP+21, kaT_mumu_5 = kDCP+22, kaT_mutau_5 = kDCP+23,
                      kaT_tautau_5 = kDCP+24, kDelta_emu_5 = kDCP+25, kDelta_etau_5 = kDCP+26, kDelta_mutau_5 = kDCP+27,
-                     kcT_ee_6 = kDCP+28, kcT_emu_6 = kDCP+29, kcT_etau_6 = kDCP+30, kcT_mumu_6 = kDCP+31, kcT_mutau_6 = kDCP+32, 
+                     kcT_ee_6 = kDCP+28, kcT_emu_6 = kDCP+29, kcT_etau_6 = kDCP+30, kcT_mumu_6 = kDCP+31, kcT_mutau_6 = kDCP+32,
                      kcT_tautau_6 = kDCP+33, kDelta_emu_6 = kDCP+34, kDelta_etau_6 = kDCP+35, kDelta_mutau_6 = kDCP+36,
-                     kaT_ee_7 = kDCP+37, kaT_emu_7 = kDCP+38, kaT_etau_7 = kDCP+39, kaT_mumu_7 = kDCP+40, kaT_mutau_7 = kDCP+41, 
+                     kaT_ee_7 = kDCP+37, kaT_emu_7 = kDCP+38, kaT_etau_7 = kDCP+39, kaT_mumu_7 = kDCP+40, kaT_mutau_7 = kDCP+41,
                      kaT_tautau_7 = kDCP+42, kDelta_emu_7 = kDCP+43, kDelta_etau_7 = kDCP+44, kDelta_mutau_7 = kDCP+45,
-                     kcT_ee_8 = kDCP+46, kcT_emu_8 = kDCP+47, kcT_etau_8 = kDCP+48, kcT_mumu_8 = kDCP+49, kcT_mutau_8 = kDCP+50, 
+                     kcT_ee_8 = kDCP+46, kcT_emu_8 = kDCP+47, kcT_etau_8 = kDCP+48, kcT_mumu_8 = kDCP+49, kcT_mutau_8 = kDCP+50,
                      kcT_tautau_8 = kDCP+51, kDelta_emu_8 = kDCP+52, kDelta_etau_8 = kDCP+53, kDelta_mutau_8 = kDCP+54};
-  
+
   /**
    * @brief Define the neutrino and antineutrino values expected by this implementation
    */
@@ -391,11 +401,11 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   int fOscType;
 
 private:
-  
+
   /**
    * @brief Object handling the Earth model and the estimation of neutrino paths through the Earth depending on their direction
    * Paths used by PMNS objects for neutrino propagation
-   * Earth model implemented as succession of spherical shells with uniform density 
+   * Earth model implemented as succession of spherical shells with uniform density
    */
   OscProb::PremModel PremModel;
 
@@ -408,6 +418,17 @@ private:
    * @brief Double storing the detector depth in km
    */
   double fDetDepth;
+
+  /**
+   * @brief Maximum generated flavour for ProbMatrix calculation
+   */
+  int fMaxGenFlavour;
+
+  /**
+   * @brief Maximum detected flavour for ProbMatrix calculation
+   */
+  int fMaxDetFlavour;
+
 };
 
 #endif


### PR DESCRIPTION
# Pull request description:

We can improve the OscProb speed by computing all detected flavours at once using the OscProb::PMNS_Base::ProbMatrix function.

## Changes or fixes:

- Using ProbMatrix as probability method
- Made the code a bit more DRY by reusing functions
