### PR TITLE
If omp_num_threads not defined just print all available threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/NuOscillatorUtils.cmake)
 # By default GPU is off
 DefineEnabledRequiredSwitch(UseGPU 0)
 
-set(NUOSCILLATOR_VERSION 1.1.0)
+set(NUOSCILLATOR_VERSION 1.1.1)
 
 if(${UseGPU} EQUAL 0)
   project(NUOSCILLATOR VERSION ${NUOSCILLATOR_VERSION} LANGUAGES CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,15 +92,19 @@ else()
 endif()
 
 if(${UseMultithreading} EQUAL 1)
-  cmessage(STATUS "\tUsing Multithreading with nThreads=$ENV{OMP_NUM_THREADS}")
+  if(DEFINED ENV{OMP_NUM_THREADS} AND NOT "$ENV{OMP_NUM_THREADS}" STREQUAL "")
+    cmessage(STATUS "\tUsing Multithreading with nThreads=$ENV{OMP_NUM_THREADS}")
+  else()
+    execute_process(
+      COMMAND lscpu
+      COMMAND awk -F: "/^(CPU\\(s\\)|CPU):/ {gsub(/^[ \\t]+/, \"\", \$2); print \$2; exit}"
+      OUTPUT_VARIABLE CPU_COUNT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    cmessage(STATUS "\tUsing Multithreading with nThreads=${CPU_COUNT}")
+  endif()
 else()
   cmessage(STATUS "\tNot using Multithreading")
-endif()
-
-if(${UseDoubles} EQUAL 1)
-  cmessage(STATUS "\tUsing FLOAT_T=double")
-else()
-  cmessage(STATUS "\tUsing FLOAT_T=float")
 endif()
 
 if(${UseCUDAProb3} EQUAL 1 AND ${UseCUDAProb3Linear} EQUAL 1)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This give full freedom to users in how to configure NuOscillator.
 ## How to Use in Fitting Framework
 First initialise factory to produce engine defined by config. See exmaples of configs [here](https://github.com/dbarrow257/NuOscillator/tree/main/Configs)
 ```cpp
-OscillatorFactory* OscillFactory = new OscillatorFactory();
+auto OscillFactory = std::make_unique<OscillatorFactory>();
 
 std::string NuOscillatorConfigFile = "configs/NuFASTLinear.yaml");
 NuOscProbCalcers = OscillFactory->CreateOscillator(NuOscillatorConfigFile);
@@ -103,7 +103,7 @@ std::sort(EnergyArray.begin(),EnergyArray.end());
 Lastly pass energy vector and finish setup
 ```cpp
 if (!NuOscProbCalcers->EvalPointsSetInConstructor()) {
-NuOscProbCalcers->SetEnergyArrayInCalcer(EnergyArray);
+  NuOscProbCalcers->SetEnergyArrayInCalcer(EnergyArray);
 }
 NuOscProbCalcers->Setup();
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 # NuOscillator
+NuOscillator is a wrapper around oscillation calculators,
+enabling the computation of oscillation probabilities for various configurations,
+including beam oscillations, atmospheric oscillations, and sterile neutrinos with NSI effects.
+
+The framework has been adapted to integrate seamlessly with oscillation fitters like
+[MaCh3](https://github.com/mach3-software/MaCh3/tree/develop).
 
 [![Container Image](https://img.shields.io/badge/Container-Image-brightgreen)](https://github.com/dbarrow257/NuOscillator/pkgs/container/nuoscillator)
 [![Code - Doxygen](https://img.shields.io/badge/Code-Doxygen-2ea44f)](https://dbarrow257.github.io/NuOscillator/)


### PR DESCRIPTION
# Pull request description:
I personally rarely define OMP_NUM_THREADS. Then I get blank cmake message (annoing). Expanded cmake in case of not having this variable defined to print all avaialbe threads from `lscpu`.

In addition very short explanation of what NuOscillator is to make project look more professional.
## Changes or fixes:


## Examples:
<img width="412" alt="blarb" src="https://github.com/user-attachments/assets/8461ad3c-8725-44e4-9d14-b8b7b42abfb6" />
