### PR TITLE
Add linear propagation to OscProb

### DIFF
--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -1,7 +1,18 @@
 #include "OscProbCalcer_OscProb.h"
 #include <fstream>
+#include "inc/PMNS_Fast.h"
+#include "inc/PMNS_Sterile.h"
+#include "inc/PMNS_Decay.h"
+#include "inc/PMNS_Deco.h"
+#include "inc/PMNS_NSI.h"
+#include "inc/PMNS_Iter.h"
+#include "inc/PMNS_NUNM.h"
+#include "inc/PMNS_SNSI.h"
+#include "inc/PMNS_LIV.h"
 
-OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBase(Config_)
+OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) :
+  OscProbCalcerBase(Config_),
+  fPMNSObj(nullptr)
 {
   //=======
   //Grab information from the config
@@ -33,7 +44,7 @@ OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBa
   fNeutrinoTypes[1] = Nubar;
 
   fOscType = PMNS_StrToInt(OscMatrix);
-  fNOscParams = GetNOscParams(fOscType);
+  fNOscParams = GetNOscParams();
 
   fMaxGenFlavour = 1;
   fMaxDetFlavour = 1;
@@ -51,6 +62,7 @@ OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBa
 }
 
 OscProbCalcerOscProb::~OscProbCalcerOscProb() {
+  delete fPMNSObj;
 }
 
 void OscProbCalcerOscProb::SetupPropagator() {
@@ -60,6 +72,25 @@ void OscProbCalcerOscProb::SetupPropagator() {
 
   PremModel = OscProb::PremModel(premfile);
 
+  fPMNSObj = GetPMNSObj();
+
+}
+
+OscProb::PMNS_Base* OscProbCalcerOscProb::GetPMNSObj() {
+
+ if(fOscType==kPMNSSterile1) return new OscProb::PMNS_Sterile(4);
+ if(fOscType==kPMNSSterile2) return new OscProb::PMNS_Sterile(5);
+ if(fOscType==kPMNSSterile3) return new OscProb::PMNS_Sterile(6);
+ if(fOscType==kDecay)        return new OscProb::PMNS_Decay();
+ if(fOscType==kDeco)         return new OscProb::PMNS_Deco();
+ if(fOscType==kNSI)          return new OscProb::PMNS_NSI();
+ if(fOscType==kSNSI)         return new OscProb::PMNS_SNSI();
+ if(fOscType==kIter)         return new OscProb::PMNS_Iter();
+ if(fOscType==kNUNM)         return new OscProb::PMNS_NUNM();
+ if(fOscType==kLIV)          return new OscProb::PMNS_LIV();
+
+ return new OscProb::PMNS_Fast();
+
 }
 
 void OscProbCalcerOscProb::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
@@ -68,73 +99,29 @@ void OscProbCalcerOscProb::CalculateProbabilities(const std::vector<FLOAT_T>& Os
 
   PremModel.SetDetPos(det_radius);
 
-  switch(fOscType) {
-    case kFast:
-      CalcProbPMNS_Fast(OscParams);
-      break;
+  SetPMNSParams(OscParams);
 
-    case kPMNSSterile1:
-      CalcProbPMNS_Sterile(OscParams, 4);
-      break;
+  CalcProbPMNS();
 
-    case kPMNSSterile2:
-      CalcProbPMNS_Sterile(OscParams, 5);
-      break;
-
-    case kPMNSSterile3:
-      CalcProbPMNS_Sterile(OscParams, 6);
-      break;
-
-    case kDecay:
-      CalcProbPMNS_Decay(OscParams);
-      break;
-
-    case kDeco:
-      CalcProbPMNS_Deco(OscParams);
-      break;
-
-    case kNSI:
-      CalcProbPMNS_NSI(OscParams);
-      break;
-
-    case kSNSI:
-      CalcProbPMNS_SNSI(OscParams);
-      break;
-
-    case kIter:
-      CalcProbPMNS_Iter(OscParams);
-      break;
-
-    case kNUNM:
-      CalcProbPMNS_NUNM(OscParams);
-      break;
-
-    case kLIV:
-      CalcProbPMNS_LIV(OscParams);
-      break;
-
-    default:
-      break;
-  }
 }
 
-void OscProbCalcerOscProb::CalcProbPMNS(OscProb::PMNS_Base* myPMNS) {
+void OscProbCalcerOscProb::CalcProbPMNS() {
 
   for (int iNuType = 0; iNuType < fNNeutrinoTypes; iNuType++) {
 
-    myPMNS->SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
+    fPMNSObj->SetIsNuBar(fNeutrinoTypes[iNuType]==Nubar);
 
     for (int iCosineZ = 0; iCosineZ < fNCosineZPoints; iCosineZ++) {
 
       PremModel.FillPath(fCosineZArray[iCosineZ]);
 
-      myPMNS->SetPath(PremModel.GetNuPath());
+      fPMNSObj->SetPath(PremModel.GetNuPath());
 
       for (int iEnergy = 0; iEnergy < fNEnergyPoints; iEnergy++) {
 
-        OscProb::matrixD probMatrix = myPMNS->ProbMatrix(fMaxGenFlavour,
-                                                         fMaxDetFlavour,
-                                                         fEnergyArray[iEnergy]);
+        OscProb::matrixD probMatrix = fPMNSObj->ProbMatrix(fMaxGenFlavour,
+                                                          fMaxDetFlavour,
+                                                          fEnergyArray[iEnergy]);
 
         for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
 
@@ -150,81 +137,6 @@ void OscProbCalcerOscProb::CalcProbPMNS(OscProb::PMNS_Base* myPMNS) {
       }
     }
   }
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_Fast(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_Fast myPMNS;
-  SetPMNSParams(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_Sterile(const std::vector<FLOAT_T>& OscParams, int neutrino_number) {
-
-  OscProb::PMNS_Sterile myPMNS(neutrino_number);
-  SetPMNSParams_Sterile(&myPMNS, OscParams);
-
-  std::cout << "Proba with PMNS Sterile and " << neutrino_number << " neutrinos" << std::endl;
-
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_Decay(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_Decay myPMNS;
-  SetPMNSParams_Decay(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_Deco(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_Deco myPMNS;
-  SetPMNSParams_Deco(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_NSI(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_NSI myPMNS;
-  SetPMNSParams_NSI(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_SNSI(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_SNSI myPMNS;
-  SetPMNSParams_SNSI(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_Iter(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_Iter myPMNS;
-  SetPMNSParams_Iter(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_NUNM(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_NUNM myPMNS;
-  SetPMNSParams_NUNM(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
-
-}
-
-void OscProbCalcerOscProb::CalcProbPMNS_LIV(const std::vector<FLOAT_T>& OscParams) {
-
-  OscProb::PMNS_LIV myPMNS;
-  SetPMNSParams_LIV(&myPMNS, OscParams);
-  return CalcProbPMNS(&myPMNS);
 
 }
 
@@ -247,273 +159,181 @@ long OscProbCalcerOscProb::DefineWeightArraySize() {
   return nCalculationPoints;
 }
 
-void OscProbCalcerOscProb::SetPMNSParams(OscProb::PMNS_Base* pmns,
-                                         const std::vector<FLOAT_T>& OscParams) {
-
-  double th12 = asin(sqrt(OscParams[kTH12]));
-  double th13 = asin(sqrt(OscParams[kTH13]));
-  double th23 = asin(sqrt(OscParams[kTH23]));
-  double dcp  = OscParams[kDCP];
-  double dm21 = OscParams[kDM12];
-
-  //Need to convert OscParams[kDM23] to kDM31
-  double dm31 = OscParams[kDM23] + OscParams[kDM12]; // eV^2
+void OscProbCalcerOscProb::SetPMNSParams(const std::vector<FLOAT_T>& OscParams) {
 
   // Set PMNS parameters
-  pmns->SetDm(2, dm21);
-  pmns->SetDm(3, dm31);
-  pmns->SetAngle(1,2, th12);
-  pmns->SetAngle(1,3, th13);
-  pmns->SetAngle(2,3, th23);
-  pmns->SetDelta(1,3, dcp);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_Sterile(OscProb::PMNS_Sterile* Sterile,
-                                                 const std::vector<FLOAT_T>& OscParams) {
-  SetPMNSParams(Sterile, OscParams);
+  fPMNSObj->SetDm(2, OscParams[kDM12]);
+  fPMNSObj->SetDm(3, OscParams[kDM23] + OscParams[kDM12]);
+  fPMNSObj->SetAngle(1,2, asin(sqrt(OscParams[kTH12])));
+  fPMNSObj->SetAngle(1,3, asin(sqrt(OscParams[kTH13])));
+  fPMNSObj->SetAngle(2,3, asin(sqrt(OscParams[kTH23])));
+  fPMNSObj->SetDelta(1,3, OscParams[kDCP]);
 
   //Set PMNS parameters for first sterile state
-  Sterile->SetDm(4, OscParams[kDM14]);
-  Sterile->SetAngle(1,4, asin(sqrt(OscParams[kTH14])));
-  Sterile->SetAngle(2,4, asin(sqrt(OscParams[kTH24])));
-  Sterile->SetAngle(3,4, asin(sqrt(OscParams[kTH34])));
-  Sterile->SetDelta(1,4, OscParams[kDelta14]);
-  Sterile->SetDelta(2,4, OscParams[kDelta24]);
+  if(OscProb::PMNS_Sterile* Sterile = dynamic_cast<OscProb::PMNS_Sterile*>(fPMNSObj)) {
+    Sterile->SetDm(4, OscParams[kDM14]);
+    Sterile->SetAngle(1,4, asin(sqrt(OscParams[kTH14])));
+    Sterile->SetAngle(2,4, asin(sqrt(OscParams[kTH24])));
+    Sterile->SetAngle(3,4, asin(sqrt(OscParams[kTH34])));
+    Sterile->SetDelta(1,4, OscParams[kDelta14]);
+    Sterile->SetDelta(2,4, OscParams[kDelta24]);
 
-  //Set PMNS parameters for second sterile state if there is one
-  if(fOscType == kPMNSSterile2 || fOscType == kPMNSSterile3) {
-    Sterile->SetDm(5, OscParams[kDM15]);
-    Sterile->SetAngle(1,5, asin(sqrt(OscParams[kTH15])));
-    Sterile->SetAngle(2,5, asin(sqrt(OscParams[kTH25])));
-    Sterile->SetAngle(3,5, asin(sqrt(OscParams[kTH35])));
-    Sterile->SetAngle(4,5, asin(sqrt(OscParams[kTH45])));
-    Sterile->SetDelta(1,5, OscParams[kDelta15]);
-    Sterile->SetDelta(2,5, OscParams[kDelta25]);
-    Sterile->SetDelta(3,5, OscParams[kDelta35]);
+    //Set PMNS parameters for second sterile state
+    if(fOscType == kPMNSSterile2 || fOscType == kPMNSSterile3) {
+      Sterile->SetDm(5, OscParams[kDM15]);
+      Sterile->SetAngle(1,5, asin(sqrt(OscParams[kTH15])));
+      Sterile->SetAngle(2,5, asin(sqrt(OscParams[kTH25])));
+      Sterile->SetAngle(3,5, asin(sqrt(OscParams[kTH35])));
+      Sterile->SetAngle(4,5, asin(sqrt(OscParams[kTH45])));
+      Sterile->SetDelta(1,5, OscParams[kDelta15]);
+      Sterile->SetDelta(2,5, OscParams[kDelta25]);
+      Sterile->SetDelta(3,5, OscParams[kDelta35]);
+    }
+
+    //Set PMNS parameters for third sterile state
+    if(fOscType == kPMNSSterile3) {
+      Sterile->SetDm(6, OscParams[kDM16]);
+      Sterile->SetAngle(1,6, asin(sqrt(OscParams[kTH16])));
+      Sterile->SetAngle(2,6, asin(sqrt(OscParams[kTH26])));
+      Sterile->SetAngle(3,6, asin(sqrt(OscParams[kTH36])));
+      Sterile->SetAngle(4,6, asin(sqrt(OscParams[kTH46])));
+      Sterile->SetAngle(5,6, asin(sqrt(OscParams[kTH56])));
+      Sterile->SetDelta(1,6, OscParams[kDelta16]);
+      Sterile->SetDelta(2,6, OscParams[kDelta26]);
+      Sterile->SetDelta(3,6, OscParams[kDelta36]);
+      Sterile->SetDelta(4,6, OscParams[kDelta46]);
+    }
   }
-
-  //Set PMNS parameters for third sterile state if there is one
-  if(fOscType == kPMNSSterile3) {
-    Sterile->SetDm(6, OscParams[kDM16]);
-    Sterile->SetAngle(1,6, asin(sqrt(OscParams[kTH16])));
-    Sterile->SetAngle(2,6, asin(sqrt(OscParams[kTH26])));
-    Sterile->SetAngle(3,6, asin(sqrt(OscParams[kTH36])));
-    Sterile->SetAngle(4,6, asin(sqrt(OscParams[kTH46])));
-    Sterile->SetAngle(5,6, asin(sqrt(OscParams[kTH56])));
-    Sterile->SetDelta(1,6, OscParams[kDelta16]);
-    Sterile->SetDelta(2,6, OscParams[kDelta26]);
-    Sterile->SetDelta(3,6, OscParams[kDelta36]);
-    Sterile->SetDelta(4,6, OscParams[kDelta46]);
-  }
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_Decay(OscProb::PMNS_Decay* Decay,
-                                               const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams(Decay, OscParams);
 
   // Set Decay parameters
-  Decay->SetAlpha2(OscParams[kAlpha2]);
-  Decay->SetAlpha3(OscParams[kAlpha3]);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_Deco(OscProb::PMNS_Deco* Deco,
-                                              const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams(Deco, OscParams);
+  if(OscProb::PMNS_Decay* Decay = dynamic_cast<OscProb::PMNS_Decay*>(fPMNSObj)) {
+    Decay->SetAlpha2(OscParams[kAlpha2]);
+    Decay->SetAlpha3(OscParams[kAlpha3]);
+  }
 
   // Set Deco parameters
-  Deco->SetGamma(2, OscParams[kGamma21]);
-  Deco->SetGamma(3, OscParams[kGamma31]);
-  Deco->SetDecoAngle(OscParams[kDecoAngle]);
-  Deco->SetPower(OscParams[kPower]);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_NSI(OscProb::PMNS_NSI* NSI,
-                                             const std::vector<FLOAT_T>& OscParams) {
-  SetPMNSParams(NSI, OscParams);
+  if(OscProb::PMNS_Deco* Deco = dynamic_cast<OscProb::PMNS_Deco*>(fPMNSObj)) {
+    Deco->SetGamma(2, OscParams[kGamma21]);
+    Deco->SetGamma(3, OscParams[kGamma31]);
+    Deco->SetDecoAngle(OscParams[kDecoAngle]);
+    Deco->SetPower(OscParams[kPower]);
+  }
 
   // Set NSI parameters
-  NSI->SetNSI(OscParams[kEps_ee],
-              OscParams[kEps_emu],
-              OscParams[kEps_etau],
-              OscParams[kEps_mumu],
-              OscParams[kEps_mutau],
-              OscParams[kEps_tautau],
-              OscParams[kDelta_emu],
-              OscParams[kDelta_etau],
-              OscParams[kDelta_mutau]);
+  if(OscProb::PMNS_NSI* NSI = dynamic_cast<OscProb::PMNS_NSI*>(fPMNSObj)) {
+    NSI->SetNSI(OscParams[kEps_ee],
+                OscParams[kEps_emu],
+                OscParams[kEps_etau],
+                OscParams[kEps_mumu],
+                OscParams[kEps_mutau],
+                OscParams[kEps_tautau],
+                OscParams[kDelta_emu],
+                OscParams[kDelta_etau],
+                OscParams[kDelta_mutau]);
 
-  NSI->SetFermCoup(OscParams[kElecCoup],
-                   OscParams[kUpCoup],
-                   OscParams[kDownCoup]);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_SNSI(OscProb::PMNS_SNSI* SNSI,
-                                              const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams_NSI(SNSI, OscParams);
+    NSI->SetFermCoup(OscParams[kElecCoup],
+                     OscParams[kUpCoup],
+                     OscParams[kDownCoup]);
+  }
 
   // Set SNSI parameters
-  SNSI->SetLowestMass(OscParams[kLightMass]);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_Iter(OscProb::PMNS_Iter* Iter,
-                                              const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams(Iter, OscParams);
+  if(OscProb::PMNS_SNSI* SNSI = dynamic_cast<OscProb::PMNS_SNSI*>(fPMNSObj)) {
+    SNSI->SetLowestMass(OscParams[kLightMass]);
+  }
 
   // Set Iter parameters
-  Iter->SetPrec(OscParams[kPrec]);
+  if(OscProb::PMNS_Iter* Iter = dynamic_cast<OscProb::PMNS_Iter*>(fPMNSObj)) {
+    Iter->SetPrec(OscParams[kPrec]);
+  }
 
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_NUNM(OscProb::PMNS_NUNM* NUNM,
-                                              const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams(NUNM, OscParams);
-
-  // Set PMNS parameters
-  NUNM->SetAlpha_11(OscParams[kAlpha11]);
-  NUNM->SetAlpha_22(OscParams[kAlpha22]);
-  NUNM->SetAlpha_33(OscParams[kAlpha33]);
-  NUNM->SetAlpha_21(OscParams[kAlpha21], OscParams[kPhi21]);
-  NUNM->SetAlpha_31(OscParams[kAlpha31], OscParams[kPhi31]);
-  NUNM->SetAlpha_32(OscParams[kAlpha32], OscParams[kPhi32]);
-  NUNM->SetFracVnc(OscParams[kFracVnc]);
-
-}
-
-void OscProbCalcerOscProb::SetPMNSParams_LIV(OscProb::PMNS_LIV *LIV, const std::vector<FLOAT_T>& OscParams) {
-
-  SetPMNSParams(LIV, OscParams);
+  // Set NUNM parameters
+  if(OscProb::PMNS_NUNM* NUNM = dynamic_cast<OscProb::PMNS_NUNM*>(fPMNSObj)) {
+    NUNM->SetAlpha_11(OscParams[kAlpha11]);
+    NUNM->SetAlpha_22(OscParams[kAlpha22]);
+    NUNM->SetAlpha_33(OscParams[kAlpha33]);
+    NUNM->SetAlpha_21(OscParams[kAlpha21], OscParams[kPhi21]);
+    NUNM->SetAlpha_31(OscParams[kAlpha31], OscParams[kPhi31]);
+    NUNM->SetAlpha_32(OscParams[kAlpha32], OscParams[kPhi32]);
+    NUNM->SetFracVnc(OscParams[kFracVnc]);
+  }
 
   // Set LIV parameters
-  LIV->SetaT(0, 0, 3, OscParams[kaT_ee_3], 0.);
-  LIV->SetaT(0, 1, 3, OscParams[kaT_emu_3], OscParams[kDelta_emu_3]);
-  LIV->SetaT(0, 2, 3, OscParams[kaT_etau_3], OscParams[kDelta_etau_3]);
-  LIV->SetaT(1, 1, 3, OscParams[kaT_mumu_3], 0.);
-  LIV->SetaT(1, 2, 3, OscParams[kaT_mutau_3], OscParams[kDelta_mutau_3]);
-  LIV->SetaT(2, 2, 3, OscParams[kaT_tautau_3], 0.);
-  LIV->SetcT(0, 0, 4, OscParams[kcT_ee_4], 0.);
-  LIV->SetcT(0, 1, 4, OscParams[kcT_emu_4], OscParams[kDelta_emu_4]);
-  LIV->SetcT(0, 2, 4, OscParams[kcT_etau_4], OscParams[kDelta_etau_4]);
-  LIV->SetcT(1, 1, 4, OscParams[kcT_mumu_4], 0.);
-  LIV->SetcT(1, 2, 4, OscParams[kcT_mutau_4], OscParams[kDelta_mutau_4]);
-  LIV->SetcT(2, 2, 4, OscParams[kcT_tautau_4], 0.);
-  LIV->SetaT(0, 0, 5, OscParams[kaT_ee_5], 0.);
-  LIV->SetaT(0, 1, 5, OscParams[kaT_emu_5], OscParams[kDelta_emu_5]);
-  LIV->SetaT(0, 2, 5, OscParams[kaT_etau_5], OscParams[kDelta_etau_5]);
-  LIV->SetaT(1, 1, 5, OscParams[kaT_mumu_5], 0.);
-  LIV->SetaT(1, 2, 5, OscParams[kaT_mutau_5], OscParams[kDelta_mutau_5]);
-  LIV->SetaT(2, 2, 5, OscParams[kaT_tautau_5], 0.);
-  LIV->SetcT(0, 0, 6, OscParams[kcT_ee_6], 0.);
-  LIV->SetcT(0, 1, 6, OscParams[kcT_emu_6], OscParams[kDelta_emu_6]);
-  LIV->SetcT(0, 2, 6, OscParams[kcT_etau_6], OscParams[kDelta_etau_6]);
-  LIV->SetcT(1, 1, 6, OscParams[kcT_mumu_6], 0.);
-  LIV->SetcT(1, 2, 6, OscParams[kcT_mutau_6], OscParams[kDelta_mutau_6]);
-  LIV->SetcT(2, 2, 6, OscParams[kcT_tautau_6], 0.);
-  LIV->SetaT(0, 0, 7, OscParams[kaT_ee_7], 0.);
-  LIV->SetaT(0, 1, 7, OscParams[kaT_emu_7], OscParams[kDelta_emu_7]);
-  LIV->SetaT(0, 2, 7, OscParams[kaT_etau_7], OscParams[kDelta_etau_7]);
-  LIV->SetaT(1, 1, 7, OscParams[kaT_mumu_7], 0.);
-  LIV->SetaT(1, 2, 7, OscParams[kaT_mutau_7], OscParams[kDelta_mutau_7]);
-  LIV->SetaT(2, 2, 7, OscParams[kaT_tautau_7], 0.);
-  LIV->SetcT(0, 0, 8, OscParams[kcT_ee_8], 0.);
-  LIV->SetcT(0, 1, 8, OscParams[kcT_emu_8], OscParams[kDelta_emu_8]);
-  LIV->SetcT(0, 2, 8, OscParams[kcT_etau_8], OscParams[kDelta_etau_8]);
-  LIV->SetcT(1, 1, 8, OscParams[kcT_mumu_8], 0.);
-  LIV->SetcT(1, 2, 8, OscParams[kcT_mutau_8], OscParams[kDelta_mutau_8]);
-  LIV->SetcT(2, 2, 8, OscParams[kcT_tautau_8], 0.);
+  if(OscProb::PMNS_LIV* LIV = dynamic_cast<OscProb::PMNS_LIV*>(fPMNSObj)) {
+    LIV->SetaT(0, 0, 3, OscParams[kaT_ee_3], 0.);
+    LIV->SetaT(0, 1, 3, OscParams[kaT_emu_3], OscParams[kDelta_emu_3]);
+    LIV->SetaT(0, 2, 3, OscParams[kaT_etau_3], OscParams[kDelta_etau_3]);
+    LIV->SetaT(1, 1, 3, OscParams[kaT_mumu_3], 0.);
+    LIV->SetaT(1, 2, 3, OscParams[kaT_mutau_3], OscParams[kDelta_mutau_3]);
+    LIV->SetaT(2, 2, 3, OscParams[kaT_tautau_3], 0.);
+    LIV->SetcT(0, 0, 4, OscParams[kcT_ee_4], 0.);
+    LIV->SetcT(0, 1, 4, OscParams[kcT_emu_4], OscParams[kDelta_emu_4]);
+    LIV->SetcT(0, 2, 4, OscParams[kcT_etau_4], OscParams[kDelta_etau_4]);
+    LIV->SetcT(1, 1, 4, OscParams[kcT_mumu_4], 0.);
+    LIV->SetcT(1, 2, 4, OscParams[kcT_mutau_4], OscParams[kDelta_mutau_4]);
+    LIV->SetcT(2, 2, 4, OscParams[kcT_tautau_4], 0.);
+    LIV->SetaT(0, 0, 5, OscParams[kaT_ee_5], 0.);
+    LIV->SetaT(0, 1, 5, OscParams[kaT_emu_5], OscParams[kDelta_emu_5]);
+    LIV->SetaT(0, 2, 5, OscParams[kaT_etau_5], OscParams[kDelta_etau_5]);
+    LIV->SetaT(1, 1, 5, OscParams[kaT_mumu_5], 0.);
+    LIV->SetaT(1, 2, 5, OscParams[kaT_mutau_5], OscParams[kDelta_mutau_5]);
+    LIV->SetaT(2, 2, 5, OscParams[kaT_tautau_5], 0.);
+    LIV->SetcT(0, 0, 6, OscParams[kcT_ee_6], 0.);
+    LIV->SetcT(0, 1, 6, OscParams[kcT_emu_6], OscParams[kDelta_emu_6]);
+    LIV->SetcT(0, 2, 6, OscParams[kcT_etau_6], OscParams[kDelta_etau_6]);
+    LIV->SetcT(1, 1, 6, OscParams[kcT_mumu_6], 0.);
+    LIV->SetcT(1, 2, 6, OscParams[kcT_mutau_6], OscParams[kDelta_mutau_6]);
+    LIV->SetcT(2, 2, 6, OscParams[kcT_tautau_6], 0.);
+    LIV->SetaT(0, 0, 7, OscParams[kaT_ee_7], 0.);
+    LIV->SetaT(0, 1, 7, OscParams[kaT_emu_7], OscParams[kDelta_emu_7]);
+    LIV->SetaT(0, 2, 7, OscParams[kaT_etau_7], OscParams[kDelta_etau_7]);
+    LIV->SetaT(1, 1, 7, OscParams[kaT_mumu_7], 0.);
+    LIV->SetaT(1, 2, 7, OscParams[kaT_mutau_7], OscParams[kDelta_mutau_7]);
+    LIV->SetaT(2, 2, 7, OscParams[kaT_tautau_7], 0.);
+    LIV->SetcT(0, 0, 8, OscParams[kcT_ee_8], 0.);
+    LIV->SetcT(0, 1, 8, OscParams[kcT_emu_8], OscParams[kDelta_emu_8]);
+    LIV->SetcT(0, 2, 8, OscParams[kcT_etau_8], OscParams[kDelta_etau_8]);
+    LIV->SetcT(1, 1, 8, OscParams[kcT_mumu_8], 0.);
+    LIV->SetcT(1, 2, 8, OscParams[kcT_mutau_8], OscParams[kDelta_mutau_8]);
+    LIV->SetcT(2, 2, 8, OscParams[kcT_tautau_8], 0.);
+  }
+
 }
 
 int OscProbCalcerOscProb::PMNS_StrToInt(std::string PMNSType) {
-  if (PMNSType == "Fast" || PMNSType == "fast") {
-    return kFast;
-  }
-  else if (PMNSType == "Sterile+1" || PMNSType == "Sterile1") {
-    return kPMNSSterile1;
-  }
-  else if (PMNSType == "Sterile+2" || PMNSType == "Sterile2") {
-    return kPMNSSterile2;
-  }
-  else if (PMNSType == "Sterile+3" || PMNSType == "Sterile3") {
-    return kPMNSSterile3;
-  }
-  else if (PMNSType == "Decay" || PMNSType == "decay") {
-    return kDecay;
-  }
-  else if (PMNSType == "Deco" || PMNSType == "deco") {
-    return kDeco;
-  }
-  else if (PMNSType == "NSI" || PMNSType == "nsi") {
-    return kNSI;
-  }
-  else if (PMNSType == "LIV" || PMNSType == "liv") {
-    return kLIV;
-  }
-  else if (PMNSType == "NUNM" || PMNSType == "nunm") {
-    return kNUNM;
-  }
-  else if (PMNSType == "SNSI" || PMNSType == "snsi") {
-    return kSNSI;
-  }
-  else if (PMNSType == "Iter" || PMNSType == "iter") {
-    return kIter;
-  }
-  else {
-    std::cerr << "Invalid PMNS matrix type provided:" << PMNSType << std::endl;
-    throw std::runtime_error("Invalid setup");
-  }
+
+  if (PMNSType == "Fast" || PMNSType == "fast")          return kFast;
+  if (PMNSType == "Sterile+1" || PMNSType == "Sterile1") return kPMNSSterile1;
+  if (PMNSType == "Sterile+2" || PMNSType == "Sterile2") return kPMNSSterile2;
+  if (PMNSType == "Sterile+3" || PMNSType == "Sterile3") return kPMNSSterile3;
+  if (PMNSType == "Decay" || PMNSType == "decay")        return kDecay;
+  if (PMNSType == "Deco" || PMNSType == "deco")          return kDeco;
+  if (PMNSType == "NSI" || PMNSType == "nsi")            return kNSI;
+  if (PMNSType == "LIV" || PMNSType == "liv")            return kLIV;
+  if (PMNSType == "NUNM" || PMNSType == "nunm")          return kNUNM;
+  if (PMNSType == "SNSI" || PMNSType == "snsi")          return kSNSI;
+  if (PMNSType == "Iter" || PMNSType == "iter")          return kIter;
+
+  std::cerr << "Invalid PMNS matrix type provided:" << PMNSType << std::endl;
+  throw std::runtime_error("Invalid setup");
 
   return -1;
+
 }
 
 
-int OscProbCalcerOscProb::GetNOscParams(int OscType) {
-  if (OscType == kFast) {
-    return kNOscParams;
-  }
-  else if (OscType == kPMNSSterile1) {
-    return kNOscParams+6;
-  }
-  else if (OscType == kPMNSSterile2) {
-    return kNOscParams+14;
-  }
-  else if (OscType == kPMNSSterile3) {
-    return kNOscParams+24;
-  }
-  else if (OscType == kDecay) {
-    return kNOscParams+2;
-  }
-  else if (OscType == kDeco) {
-    return kNOscParams+4;
-  }
-  else if (OscType == kNSI) {
-    return kNOscParams+12;
-  }
-  else if (OscType == kIter) {
-    return kNOscParams+1;
-  }
-  else if (OscType == kNUNM) {
-    return kNOscParams+10;
-  }
-  else if (OscType == kLIV) {
-    return kNOscParams+54;
-  }
-  else if (OscType == kSNSI) {
-    return kNOscParams+13;
-  }
-  else {
-    std::cerr << "Invalid PMNS matrix type provided:" << OscType << std::endl;
-    throw std::runtime_error("Invalid setup");
-  }
+int OscProbCalcerOscProb::GetNOscParams() {
 
-  return -1;
+  if (fOscType == kPMNSSterile1) return kNOscParams_Sterile1;
+  if (fOscType == kPMNSSterile2) return kNOscParams_Sterile2;
+  if (fOscType == kPMNSSterile3) return kNOscParams_Sterile3;
+  if (fOscType == kDecay)        return kNOscParams_Decay;
+  if (fOscType == kDeco)         return kNOscParams_Deco;
+  if (fOscType == kNSI)          return kNOscParams_NSI;
+  if (fOscType == kIter)         return kNOscParams_Iter;
+  if (fOscType == kNUNM)         return kNOscParams_NUNM;
+  if (fOscType == kLIV)          return kNOscParams_LIV;
+  if (fOscType == kSNSI)         return kNOscParams_SNSI;
+
+  return kNOscParams;
+
 }

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -309,17 +309,20 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kDeltaij -> CP violating phase between states i and j
    * kDM1j -> mass squared difference between states 1 and j in eV^2
    */
-  enum OscParams_Sterile{kTH14=kDCP+1, kTH24=kDCP+2, kTH34=kDCP+3, kDM14=kDCP+4, kDelta14=kDCP+5, kDelta24=kDCP+6,
-                         kTH15=kDCP+7, kTH25=kDCP+8, kTH35=kDCP+9, kTH45=kDCP+10, kDM15=kDCP+11, kDelta15=kDCP+12, kDelta25=kDCP+13, kDelta35=kDCP+14,
-                         kTH16=kDCP+15, kTH26=kDCP+16, kTH36=kDCP+17, kTH46=kDCP+18, kTH56=kDCP+19, kDM16=kDCP+20,
-                         kDelta16=kDCP+21, kDelta26=kDCP+22, kDelta36=kDCP+23, kDelta46=kDCP+24};
+  enum OscParams_Sterile{kTH14 = kNOscParams, kTH24, kTH34, kDM14,
+                         kDelta14, kDelta24,
+                         kTH15, kTH25, kTH35, kTH45, kDM15,
+                         kDelta15, kDelta25, kDelta35,
+                         kTH16, kTH26, kTH36, kTH46, kTH56, kDM16,
+                         kDelta16, kDelta26, kDelta36, kDelta46,
+                         kNOscParams_Sterile};
 
   /**
    * @brief Definition of extra oscillation parameters for PMNS_Decay class
    * kAlpha2 = m2/tau2, mass and lifetime of the 2nd state in the restframe, must be positive and units are eV^2
    * kAlpha3 = m3/tau3, mass and lifetime of the 3rd state in the restframe, must be positive and units are eV^2
    */
-  enum OscParams_Decay{kAlpha2 = kDCP+1, kAlpha3 = kDCP+2};
+  enum OscParams_Decay{kAlpha2 = kNOscParams, kAlpha3, kNOscParams_Decay};
 
     /**
    * @brief Definition of extra oscillation parameters for PMNS_Deco class
@@ -328,7 +331,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kDecoAngle decoherence angle
    * kPower power index of decoherence energy dependence
    */
-  enum OscParams_Deco{kGamma21 = kDCP+1, kGamma31 = kDCP+2, kDecoAngle = kDCP+3, kPower = kDCP+4};
+  enum OscParams_Deco{kGamma21 = kNOscParams, kGamma31, kDecoAngle, kPower, kNOscParams_Deco};
 
    /**
    * @brief Definition of extra oscillation parameters for PMNS_NSI class
@@ -338,9 +341,10 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kUpCoup u-quark coupling
    * kDownCoup d-quark coupling
    */
-  enum OscParams_NSI{kEps_ee = kDCP+1, kEps_emu = kDCP+2, kEps_etau = kDCP+3, kEps_mumu = kDCP+4,
-                     kEps_mutau = kDCP+5, kEps_tautau= kDCP+6, kDelta_emu = kDCP+7, kDelta_etau = kDCP+8,
-                     kDelta_mutau = kDCP+9, kElecCoup = kDCP+10, kUpCoup = kDCP+11, kDownCoup = kDCP+12};
+  enum OscParams_NSI{kEps_ee = kNOscParams, kEps_emu, kEps_etau, kEps_mumu,
+                     kEps_mutau, kEps_tautau, kDelta_emu, kDelta_etau,
+                     kDelta_mutau, kElecCoup, kUpCoup, kDownCoup,
+                     kNOscParams_NSI};
 
   /**
    * @brief Definition of extra oscillation parameters for PMNS_SNSI class (scalar non standard interactions)
@@ -348,13 +352,13 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kLightMass mass of lightest neutrino
    * WARNING : kEps expected in units of 1/mass^2 in MeV^-2 and not dimensionless like for PMNS_NSI
    */
-  enum OscParams_SNSI{kLightMass = kDownCoup+1};
+  enum OscParams_SNSI{kLightMass = kNOscParams_NSI, kNOscParams_SNSI};
 
    /**
    * @brief Definition of extra oscillation parameters for PMNS_Iter class
    * kPrec defines precision of the iterative method
    */
-  enum OscParams_Iter{kPrec = kDCP+1};
+  enum OscParams_Iter{kPrec = kNOscParams, kNOscParams_Iter};
 
   /**
    * @brief Definition of extra oscillation parameters for PMNS_NUNM class (non unitary neutrino mixing)
@@ -362,8 +366,8 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kPhiij complex phases for non diagonal elements between states i and j
    * kFracVnc fraction of matter potential affecting NC
    */
-  enum OscParams_NUNM{kAlpha11 = kDCP+1, kAlpha21 = kDCP+2, kAlpha31 = kDCP+3, kAlpha22 = kDCP+4, kAlpha32 = kDCP+5, kAlpha33 = kDCP+6,
-                      kPhi21 = kDCP+7, kPhi31 = kDCP+8, kPhi32 = kDCP+9, kFracVnc = kDCP+10};
+  enum OscParams_NUNM{kAlpha11 = kNOscParams, kAlpha21, kAlpha31, kAlpha22, kAlpha32, kAlpha33,
+                      kPhi21, kPhi31, kPhi32, kFracVnc, kNOscParams_NUNM};
 
   /**
    * @brief Definition of extra oscillation parameters for PMNS_LIV class (Lorentz Invariance Violation)
@@ -371,18 +375,19 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * kcT_j LIV coefficient of dimension j between 2 neutrino flavors with j = 4, 6 or 8
    * kDelta_j complex phase between 2 neutrino flavors for non diag element with dimension j
    */
-  enum OscParams_LIV{kaT_ee_3 = kDCP+1, kaT_emu_3 = kDCP+2, kaT_etau_3 = kDCP+3, kaT_mumu_3 = kDCP+4, kaT_mutau_3 = kDCP+5,
-                     kaT_tautau_3 = kDCP+6, kDelta_emu_3 = kDCP+7, kDelta_etau_3 = kDCP+8, kDelta_mutau_3 = kDCP+9,
-                     kcT_ee_4 = kDCP+10, kcT_emu_4 = kDCP+11, kcT_etau_4 = kDCP+12, kcT_mumu_4 = kDCP+13, kcT_mutau_4 = kDCP+14,
-                     kcT_tautau_4 = kDCP+15, kDelta_emu_4 = kDCP+16, kDelta_etau_4 = kDCP+17, kDelta_mutau_4 = kDCP+18,
-                     kaT_ee_5 = kDCP+19, kaT_emu_5 = kDCP+20, kaT_etau_5 = kDCP+21, kaT_mumu_5 = kDCP+22, kaT_mutau_5 = kDCP+23,
-                     kaT_tautau_5 = kDCP+24, kDelta_emu_5 = kDCP+25, kDelta_etau_5 = kDCP+26, kDelta_mutau_5 = kDCP+27,
-                     kcT_ee_6 = kDCP+28, kcT_emu_6 = kDCP+29, kcT_etau_6 = kDCP+30, kcT_mumu_6 = kDCP+31, kcT_mutau_6 = kDCP+32,
-                     kcT_tautau_6 = kDCP+33, kDelta_emu_6 = kDCP+34, kDelta_etau_6 = kDCP+35, kDelta_mutau_6 = kDCP+36,
-                     kaT_ee_7 = kDCP+37, kaT_emu_7 = kDCP+38, kaT_etau_7 = kDCP+39, kaT_mumu_7 = kDCP+40, kaT_mutau_7 = kDCP+41,
-                     kaT_tautau_7 = kDCP+42, kDelta_emu_7 = kDCP+43, kDelta_etau_7 = kDCP+44, kDelta_mutau_7 = kDCP+45,
-                     kcT_ee_8 = kDCP+46, kcT_emu_8 = kDCP+47, kcT_etau_8 = kDCP+48, kcT_mumu_8 = kDCP+49, kcT_mutau_8 = kDCP+50,
-                     kcT_tautau_8 = kDCP+51, kDelta_emu_8 = kDCP+52, kDelta_etau_8 = kDCP+53, kDelta_mutau_8 = kDCP+54};
+  enum OscParams_LIV{kaT_ee_3 = kNOscParams, kaT_emu_3, kaT_etau_3, kaT_mumu_3, kaT_mutau_3,
+                     kaT_tautau_3, kDelta_emu_3, kDelta_etau_3, kDelta_mutau_3,
+                     kcT_ee_4, kcT_emu_4, kcT_etau_4, kcT_mumu_4, kcT_mutau_4,
+                     kcT_tautau_4, kDelta_emu_4, kDelta_etau_4, kDelta_mutau_4,
+                     kaT_ee_5, kaT_emu_5, kaT_etau_5, kaT_mumu_5, kaT_mutau_5,
+                     kaT_tautau_5, kDelta_emu_5, kDelta_etau_5, kDelta_mutau_5,
+                     kcT_ee_6, kcT_emu_6, kcT_etau_6, kcT_mumu_6, kcT_mutau_6,
+                     kcT_tautau_6, kDelta_emu_6, kDelta_etau_6, kDelta_mutau_6,
+                     kaT_ee_7, kaT_emu_7, kaT_etau_7, kaT_mumu_7, kaT_mutau_7,
+                     kaT_tautau_7, kDelta_emu_7, kDelta_etau_7, kDelta_mutau_7,
+                     kcT_ee_8, kcT_emu_8, kcT_etau_8, kcT_mumu_8, kcT_mutau_8,
+                     kcT_tautau_8, kDelta_emu_8, kDelta_etau_8, kDelta_mutau_8,
+                     kNOscParams_LIV};
 
   /**
    * @brief Define the neutrino and antineutrino values expected by this implementation
@@ -393,7 +398,8 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   * @brief Different types of PMNS matrices currently supported within the analysis
   * LIV and SNSI still to be implemented at some point
   */
-  enum PMNSMatrix{kFast=0, kPMNSSterile1=1, kPMNSSterile2=2, kPMNSSterile3=3, kDecay=4, kDeco=5, kNSI=6, kSNSI=7, kIter=8, kNUNM=9, kLIV=10};
+  enum PMNSMatrix{kFast, kPMNSSterile1, kPMNSSterile2, kPMNSSterile3,
+                  kDecay, kDeco, kNSI, kSNSI, kIter, kNUNM, kLIV};
 
   /**
    * @brief Define the type for the PMNS matrix

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -59,7 +59,17 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * the oscillation probabilities in #fWeightArray.
    *
    */
-  void CalcProbPMNS();
+  void CalcProbPMNS(const std::vector<FLOAT_T>& OscParams);
+
+  /**
+   * @brief Set the neutrino path for a given cosine value
+   *
+   * Uses PremModel unless Linear OscMode, in which case a fixed baseline is used
+   *
+   * @param OscParams The parameter which may contain the baseline values
+   * @param iCosineZ the index of the zenith bin (0 for Linear)
+   */
+  void SetPath(const std::vector<FLOAT_T>& OscParams, int iCosineZ);
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -256,6 +266,11 @@ private:
    * @brief String storing the path of the density table file used to setup the Earth model
    */
   std::string premfile;
+
+  /**
+   * @brief String storing the type of propagation (Linear or other)
+   */
+  std::string fPropMode;
 
   /**
    * @brief Double storing the detector depth in km

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -3,15 +3,7 @@
 
 #include "OscProbCalcerBase.h"
 
-#include "inc/PMNS_Fast.h"
-#include "inc/PMNS_Sterile.h"
-#include "inc/PMNS_Decay.h"
-#include "inc/PMNS_Deco.h"
-#include "inc/PMNS_NSI.h"
-#include "inc/PMNS_Iter.h"
-#include "inc/PMNS_NUNM.h"
-#include "inc/PMNS_SNSI.h"
-#include "inc/PMNS_LIV.h"
+#include "inc/PMNS_Base.h"
 #include "inc/PremModel.h"
 
 /**
@@ -43,7 +35,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    */
   virtual ~OscProbCalcerOscProb();
 
-  // ========================================================================================================================================================================
+  // ==========================================================================
   // Functions which need implementation specific code
 
   /**
@@ -66,100 +58,8 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * Calculator oscillation probabilities with any PMNS object. This function both calculates and stores
    * the oscillation probabilities in #fWeightArray.
    *
-   * @param myPMNS The PMNS object to compute
    */
-  void CalcProbPMNS(OscProb::PMNS_Base* myPMNS);
-
-  /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_Fast object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_Fast(const std::vector<FLOAT_T>& OscParams);
-
-  /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_Sterile object for up to 3 additonal neutrino states. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   * @param neutrino_number Total number of neutrino states to consider
-   */
-  void CalcProbPMNS_Sterile(const std::vector<FLOAT_T>& OscParams, int neutrino_number=4);
-
-   /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_Decay object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_Decay(const std::vector<FLOAT_T>& OscParams);
-
-  /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_Deco object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_Deco(const std::vector<FLOAT_T>& OscParams);
-
-  /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_NSI object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_NSI(const std::vector<FLOAT_T>& OscParams);
-
-  /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_SNSI object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_SNSI(const std::vector<FLOAT_T>& OscParams);
-
-    /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_Iter object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_Iter(const std::vector<FLOAT_T>& OscParams);
-
-   /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_NUNM object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_NUNM(const std::vector<FLOAT_T>& OscParams);
-
-     /**
-   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
-   *
-   * Calculator oscillation probabilities with PMNS_LIV object. This function both calculates and stores
-   * the oscillation probabilities in #fWeightArray.
-   *
-   * @param OscParams The parameter set to calculate oscillation probabilities at
-   */
-  void CalcProbPMNS_LIV(const std::vector<FLOAT_T>& OscParams);
+  void CalcProbPMNS();
 
   /**
    * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
@@ -176,124 +76,50 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   /**
    * @brief Define the size of fWeightArray
    *
-   * This is implementation specific because because NuFAST is setup to calculate all oscillation channels together, whilst others calculate only a single oscillation channel.
+   * This is implementation specific because because NuFAST is setup to
+   * calculate all oscillation channels together, whilst others calculate
+   * only a single oscillation channel.
    *
    * @return Length that #fWeightArray should be initialised to
    */
   long DefineWeightArraySize() override;
 
-  // ========================================================================================================================================================================
+  // ==========================================================================
   // Functions which help setup implementation specific code
 
   /**
- * @brief Return the PMNS Matrix type corresponding to a particular string
- *
- * @param PMNSType String to convert to enum value
- *
- * @return Enum value describing the PMNS Matrix to use
- */
+   * @brief Return the PMNS Matrix type corresponding to a particular string
+   *
+   * @param PMNSType String to convert to enum value
+   *
+   * @return Enum value describing the PMNS Matrix to use
+   */
   int PMNS_StrToInt(std::string PMNSType);
 
   /**
- * @brief Return number of parameters needed for a particular type of PMNS matrix
- *
- * @param OscType int value corresponding to type of PMNS matrix
- *
- * @return number of parameters needed for the type of PMNS matrix
- */
-  int GetNOscParams(int OscType);
+   * @brief Return number of parameters needed for a particular type of PMNS matrix
+   *
+   * @return number of parameters needed for the type of PMNS matrix
+   */
+  int GetNOscParams();
 
   /**
- * @brief Set parameters for PMNS_Base
- *
- * @param PMNS object of any class
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams(OscProb::PMNS_Base* pmns, const std::vector<FLOAT_T>& OscParams);
+   * @brief Return a new instance of the appropriate PMNS object given OscType
+   *
+   * @return a PMNS object pointer
+   */
+  OscProb::PMNS_Base* GetPMNSObj();
 
   /**
- * @brief Set parameters for PMNS_Sterile with up to 3 additional neutrino states
- *
- * @param Sterile object of class PMNS_Sterile
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_Sterile(OscProb::PMNS_Sterile* Sterile, const std::vector<FLOAT_T>& OscParams);
+   * @brief Set parameters for PMNS_Base
+   *
+   * @param OscParams  The parameter set to calculate oscillation probabilities at
+   *
+   * @return Sets relevant parameters for PMNS object
+   */
+  void SetPMNSParams(const std::vector<FLOAT_T>& OscParams);
 
-   /**
- * @brief Set parameters for PMNS_Decay
- *
- * @param Decay object of class PMNS_Decay
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_Decay(OscProb::PMNS_Decay* Decay, const std::vector<FLOAT_T>& OscParams);
-
-  /**
- * @brief Set parameters for PMNS_Deco
- *
- * @param Deco object of class PMNS_Deco
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_Deco(OscProb::PMNS_Deco* Deco, const std::vector<FLOAT_T>& OscParams);
-
-  /**
- * @brief Set parameters for PMNS_NSI
- *
- * @param NSI object of class PMNS_NSI
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_NSI(OscProb::PMNS_NSI* NSI, const std::vector<FLOAT_T>& OscParams);
-
-   /**
- * @brief Set parameters for PMNS_SNSI
- *
- * @param SNSI object of class PMNS_SNSI
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_SNSI(OscProb::PMNS_SNSI* SNSI, const std::vector<FLOAT_T>& OscParams);
-
-  /**
- * @brief Set parameters for PMNS_Iter
- *
- * @param Iter object of class PMNS_Iter
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_Iter(OscProb::PMNS_Iter* Iter, const std::vector<FLOAT_T>& OscParams);
-
-  /**
- * @brief Set parameters for PMNS_NUNM
- *
- * @param NUNM object of class PMNS_NUNM
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_NUNM(OscProb::PMNS_NUNM* NUNM, const std::vector<FLOAT_T>& OscParams);
-
-    /**
- * @brief Set parameters for PMNS_LIV
- *
- * @param LIV object of class PMNS_LIV
- * @param OscParams  The parameter set to calculate oscillation probabilities at
- *
- * @return Sets relevant parameters for PMNS Matrix
- */
-  void SetPMNSParams_LIV(OscProb::PMNS_LIV* LIV, const std::vector<FLOAT_T>& OscParams);
-
-  // ========================================================================================================================================================================
+  // ==========================================================================
   // Variables which are needed for implementation specific code
 
   /**
@@ -304,18 +130,29 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   enum OscParams{kTH12, kTH23, kTH13, kDM12, kDM23, kDCP, kNOscParams};
 
   /**
-   * @brief Definition of extra oscillation parameters for PMNS_Sterile class with up to 3 additional neutrinos
+   * @brief Definition of extra oscillation parameters for PMNS_Sterile class with 1 additional neutrino
    * kTHij -> mixing angle between states i and j
    * kDeltaij -> CP violating phase between states i and j
    * kDM1j -> mass squared difference between states 1 and j in eV^2
    */
-  enum OscParams_Sterile{kTH14 = kNOscParams, kTH24, kTH34, kDM14,
-                         kDelta14, kDelta24,
-                         kTH15, kTH25, kTH35, kTH45, kDM15,
-                         kDelta15, kDelta25, kDelta35,
-                         kTH16, kTH26, kTH36, kTH46, kTH56, kDM16,
-                         kDelta16, kDelta26, kDelta36, kDelta46,
-                         kNOscParams_Sterile};
+  enum OscParams_Sterile1{kTH14 = kNOscParams, kTH24, kTH34, kDM14,
+                          kDelta14, kDelta24, kNOscParams_Sterile1};
+  /**
+   * @brief Definition of extra oscillation parameters for PMNS_Sterile class with 2 additional neutrinos
+   * kTHij -> mixing angle between states i and j
+   * kDeltaij -> CP violating phase between states i and j
+   * kDM1j -> mass squared difference between states 1 and j in eV^2
+   */
+  enum OscParams_Sterile2{kTH15 = kNOscParams_Sterile1, kTH25, kTH35, kTH45, kDM15,
+                          kDelta15, kDelta25, kDelta35, kNOscParams_Sterile2};
+  /**
+   * @brief Definition of extra oscillation parameters for PMNS_Sterile class with 3 additional neutrinos
+   * kTHij -> mixing angle between states i and j
+   * kDeltaij -> CP violating phase between states i and j
+   * kDM1j -> mass squared difference between states 1 and j in eV^2
+   */
+  enum OscParams_Sterile3{kTH16 = kNOscParams_Sterile2, kTH26, kTH36, kTH46, kTH56, kDM16,
+                          kDelta16, kDelta26, kDelta36, kDelta46, kNOscParams_Sterile3};
 
   /**
    * @brief Definition of extra oscillation parameters for PMNS_Decay class
@@ -325,22 +162,22 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   enum OscParams_Decay{kAlpha2 = kNOscParams, kAlpha3, kNOscParams_Decay};
 
     /**
-   * @brief Definition of extra oscillation parameters for PMNS_Deco class
-   * kGamma21 decoherence parameter between mass states 1 and 2
-   * kGamma31 decoherence parameter between mass states 3 and 1
-   * kDecoAngle decoherence angle
-   * kPower power index of decoherence energy dependence
-   */
+     * @brief Definition of extra oscillation parameters for PMNS_Deco class
+     * kGamma21 decoherence parameter between mass states 1 and 2
+     * kGamma31 decoherence parameter between mass states 3 and 1
+     * kDecoAngle decoherence angle
+     * kPower power index of decoherence energy dependence
+     */
   enum OscParams_Deco{kGamma21 = kNOscParams, kGamma31, kDecoAngle, kPower, kNOscParams_Deco};
 
    /**
-   * @brief Definition of extra oscillation parameters for PMNS_NSI class
-   * kEps quantity reprensenting the intensity of NSI wrt standard matter effects between the different flavours
-   * kDelta complex phases between the different flavours (non diag elements
-   * kElecCoup electron coupling
-   * kUpCoup u-quark coupling
-   * kDownCoup d-quark coupling
-   */
+     * @brief Definition of extra oscillation parameters for PMNS_NSI class
+     * kEps quantity reprensenting the intensity of NSI wrt standard matter effects between the different flavours
+     * kDelta complex phases between the different flavours (non diag elements
+     * kElecCoup electron coupling
+     * kUpCoup u-quark coupling
+     * kDownCoup d-quark coupling
+     */
   enum OscParams_NSI{kEps_ee = kNOscParams, kEps_emu, kEps_etau, kEps_mumu,
                      kEps_mutau, kEps_tautau, kDelta_emu, kDelta_etau,
                      kDelta_mutau, kElecCoup, kUpCoup, kDownCoup,
@@ -354,7 +191,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    */
   enum OscParams_SNSI{kLightMass = kNOscParams_NSI, kNOscParams_SNSI};
 
-   /**
+  /**
    * @brief Definition of extra oscillation parameters for PMNS_Iter class
    * kPrec defines precision of the iterative method
    */
@@ -395,9 +232,9 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
   enum NuType{Nu=1,Nubar=-1};
 
   /**
-  * @brief Different types of PMNS matrices currently supported within the analysis
-  * LIV and SNSI still to be implemented at some point
-  */
+   * @brief Different types of PMNS matrices currently supported within the analysis
+   * LIV and SNSI still to be implemented at some point
+   */
   enum PMNSMatrix{kFast, kPMNSSterile1, kPMNSSterile2, kPMNSSterile3,
                   kDecay, kDeco, kNSI, kSNSI, kIter, kNUNM, kLIV};
 
@@ -434,6 +271,11 @@ private:
    * @brief Maximum detected flavour for ProbMatrix calculation
    */
   int fMaxDetFlavour;
+
+  /**
+   * @brief Pointer to generic PMNS object
+   */
+  OscProb::PMNS_Base* fPMNSObj;
 
 };
 


### PR DESCRIPTION
# Pull request description:

It would be useful to propagate over a fixed baseline in OscProb to have access to BSM models in LBL analyses.

This implements a Linear propagation mode within the same OscProbCalcer_OscProb class as an option passed by the config file.

In Linear mode, the user needs to pass the baseline, density and Z/A values as the last 3 elements of the OscParams argument.

## Changes or fixes:

- Tidied up code to avoid more repetitions
- Added PropMode node to config to enable Linear propagation
