### PR TITLE
Add linear propagation to OscProb

### DIFF
--- a/Configs/Binned_OscProb.yaml
+++ b/Configs/Binned_OscProb.yaml
@@ -13,7 +13,6 @@ OscProbCalcerSetup:
   PMNSType: "Fast"
   PREMFile: "./build/_deps/oscprob-src/PremTables/prem_15layers.txt"
   DetDepth: 1.5
-  PropMode: "Atm"
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/Configs/Binned_OscProbLinear.yaml
+++ b/Configs/Binned_OscProbLinear.yaml
@@ -11,9 +11,6 @@ Binned:
 OscProbCalcerSetup:
   ImplementationName: "OscProb"
   PMNSType: "Fast"
-  PREMFile: "./build/_deps/oscprob-src/PremTables/prem_15layers.txt"
-  DetDepth: 1.5
-  PropMode: "Linear"
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/Configs/OscProbCalcerConfigs/OscProb.yaml
+++ b/Configs/OscProbCalcerConfigs/OscProb.yaml
@@ -1,12 +1,12 @@
 General:
   Verbosity: "NONE"
+  CosineZIgnored: false
 
 OscProbCalcerSetup:
   ImplementationName: "OscProb"
   PMNSType: "Fast"
   PREMFile: "./build/_deps/oscprob-src/PremTables/prem_15layers.txt"
   DetDepth: 1.5
-  PropMode: "Atm"
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/Configs/Unbinned_OscProb.yaml
+++ b/Configs/Unbinned_OscProb.yaml
@@ -8,7 +8,6 @@ OscProbCalcerSetup:
   PMNSType: "Fast"
   PREMFile: "./build/_deps/oscprob-src/PremTables/prem_15layers.txt"
   DetDepth: 1.5
-  PropMode: "Atm"
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/Configs/Unbinned_OscProbLinear.yaml
+++ b/Configs/Unbinned_OscProbLinear.yaml
@@ -6,9 +6,6 @@ General:
 OscProbCalcerSetup:
   ImplementationName: "OscProb"
   PMNSType: "Fast"
-  PREMFile: "./build/_deps/oscprob-src/PremTables/prem_15layers.txt"
-  DetDepth: 1.5
-  PropMode: "Linear"
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -129,6 +129,11 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    */
   void SetPMNSParams(const std::vector<FLOAT_T>& OscParams);
 
+  /**
+   * @brief Auxilliary function to handle ignored cosineZ cases
+   */
+  int GetNCosineZ();
+
   // ==========================================================================
   // Variables which are needed for implementation specific code
 
@@ -260,17 +265,12 @@ private:
    * Paths used by PMNS objects for neutrino propagation
    * Earth model implemented as succession of spherical shells with uniform density
    */
-  OscProb::PremModel PremModel;
+  OscProb::PremModel fPremModel;
 
   /**
    * @brief String storing the path of the density table file used to setup the Earth model
    */
-  std::string premfile;
-
-  /**
-   * @brief String storing the type of propagation (Linear or other)
-   */
-  std::string fPropMode;
+  std::string fPremFile;
 
   /**
    * @brief Double storing the detector depth in km


### PR DESCRIPTION
# Pull request description:

It would be useful to propagate over a fixed baseline in OscProb to have access to BSM models in LBL analyses.

This implements a Linear propagation mode within the same OscProbCalcerOscProb class as an option passed by the config file.

In Linear mode, the user needs to pass the baseline, density and Z/A values as the last 3 elements of the OscParams argument.

## Changes or fixes:

- Tidied up code to avoid more repetitions
- Added the option to ignore cosineZ, which enables Linear propagation
