### PR TITLE
Feature: Update SanitiseProbabilities function to allow a small precision allowance

### DIFF
--- a/OscProbCalcer/OscProbCalcerBase.cpp
+++ b/OscProbCalcer/OscProbCalcerBase.cpp
@@ -302,10 +302,12 @@ void OscProbCalcerBase::SanitiseProbabilities() {
     if ((fWeightArray[iWeight] > -1.0*PrecisionLimit) && (fWeightArray[iWeight] < 0)) {
       //Check if it's just below 0 (within some precision) and set to 0 if it is
       fWeightArray[iWeight] = 0.;
+      continue;
     }
     if ((fWeightArray[iWeight] > 1.0) && (fWeightArray[iWeight] < (1.0+PrecisionLimit))) {
       //Check if it's just above 1 (within some precision) and set to 1 if it is
       fWeightArray[iWeight] = 1.;
+      continue;
     }
     if (fWeightArray[iWeight] > (1.0+PrecisionLimit)) {
       //Check if it's above 1.0+PrecisionLimit

--- a/OscProbCalcer/OscProbCalcerBase.h
+++ b/OscProbCalcer/OscProbCalcerBase.h
@@ -469,6 +469,11 @@ class OscProbCalcerBase {
    * @brief Boolean declaring whether #fNeutrinoTypes and #fOscillationChannels have been initialised correctly
    */
   bool fNuMappingSet;
+
+  /**
+   * @brief Precision limit which allows a slight unphysical probability to pass the SanitiseProbabilities check
+   */
+  FLOAT_T PrecisionLimit;
 };
 
 #endif


### PR DESCRIPTION
# Pull request description:
Issues were being found (https://github.com/dbarrow257/NuOscillator/issues/60) when the probability was exactly equal to 1.0 or slightly above 1.0 due to numerical precision. Now allow a small precision band to set the probabilities to exactly 0.0 or 1.0 if just outside the range. The precision has a default value of 1e-6 but can be overwritable from config

## Changes or fixes:


## Examples:
