### PR TITLE
tidy: Pass std containers by refernce and more

### DIFF
--- a/Constants/OscillatorConstants.h
+++ b/Constants/OscillatorConstants.h
@@ -119,7 +119,7 @@ inline std::vector<std::string> ReturnKnownConfigs() {
  *
  * @return Enum value in #NeutrinoFlavours
  */
-inline int NeutrinoFlavour_StrToInt(std::string NuFlav) {
+inline int NeutrinoFlavour_StrToInt(const std::string& NuFlav) {
   if (NuFlav == "Electron" || NuFlav == "electron") {
     return NuOscillator::kElectron;
   } else if (NuFlav == "Muon" || NuFlav == "muon") {
@@ -175,7 +175,7 @@ inline std::string NeutrinoFlavour_IntToStr(int NuFlav) {
  *
  * @return Enum value describing the verbosity level
  */
-inline int Verbosity_StrToInt(std::string Verbosity) {
+inline int Verbosity_StrToInt(const std::string& Verbosity) {
   if (Verbosity == "NONE") {
     return NuOscillator::NONE;
   } else if (Verbosity == "INFO") {
@@ -195,7 +195,7 @@ inline int Verbosity_StrToInt(std::string Verbosity) {
  *
  * @return NuOscillator::OscillationChannel() structure with generated and detected neutrino flavours
  */
-inline NuOscillator::OscillationChannel ReturnOscillationChannel(std::string InputString) {
+inline NuOscillator::OscillationChannel ReturnOscillationChannel(const std::string& InputString) {
   std::string GeneratedFlavour = "";
   std::string DetectedFlavour = "";
 

--- a/Oscillator/OscillatorBase.cpp
+++ b/Oscillator/OscillatorBase.cpp
@@ -42,6 +42,7 @@ void OscillatorBase::InitialiseOscProbCalcer() {
   OscProbCalcerFactory* OscProbCalcFactory = new OscProbCalcerFactory();
   fOscProbCalcer = OscProbCalcFactory->CreateOscProbCalcer(Config);
   fOscProbCalcerSet = true;
+  delete OscProbCalcFactory;
 }
 
 void OscillatorBase::SetEnergyArrayInCalcer(std::vector<FLOAT_T> Array) {
@@ -67,7 +68,7 @@ void OscillatorBase::SetCosineZArrayInCalcer(std::vector<FLOAT_T> Array) {
 }
 
 // It is assumed that all OscProbCalcers within a single instance of an OscillatorBase object take the same oscillation probabilities
-void OscillatorBase::CalculateProbabilities(std::vector<FLOAT_T> OscParams) {
+void OscillatorBase::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
   if (fVerbose >= NuOscillator::INFO) {std::cout << "Calculating oscillation probabilities using OscProbCalcer Implementation:" << fOscProbCalcer->ReturnImplementationName() << " in OscillatorBase object" << std::endl;}
   fOscProbCalcer->Reweight(OscParams);
 }

--- a/Oscillator/OscillatorBase.h
+++ b/Oscillator/OscillatorBase.h
@@ -43,7 +43,7 @@ class OscillatorBase {
    *
    * @param OscParams Vector of oscillation parameters to calculate probabities at.
    */
-  void CalculateProbabilities(std::vector<FLOAT_T> OscParams);
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams);
 
   /**
    * @brief Return number of expected oscillation parameters for a particular OscProbCalcerBase::OscProbCalcerBase() instance in #fOscProbCalcers.

--- a/Oscillator/OscillatorBinned.h
+++ b/Oscillator/OscillatorBinned.h
@@ -48,7 +48,7 @@ class OscillatorBinned : public OscillatorBase {
    *
    * @return Pointer to the memory address where the calculated oscillation probability for events of the specific requested type will be stored
    */
-  const FLOAT_T* ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal=DUMMYVAL);
+  const FLOAT_T* ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal=DUMMYVAL) override;
   
   // ========================================================================================================================================================================
   // Public virtual functions which need calculater specific implementations

--- a/Oscillator/OscillatorUnbinned.h
+++ b/Oscillator/OscillatorUnbinned.h
@@ -49,7 +49,7 @@ class OscillatorUnbinned : public OscillatorBase {
    *
    * @return Pointer to the memory address where the calculated oscillation probability for events of the specific requested type will be stored
    */
-  const FLOAT_T* ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal=DUMMYVAL);
+  const FLOAT_T* ReturnWeightPointer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal=DUMMYVAL) override;
   
   // ========================================================================================================================================================================
   // Public virtual functions which need calculater specific implementations


### PR DESCRIPTION
# Pull request description:


## Changes or fixes:
- Passing std: contianers by refernce is faster
- There was single memory leak (minor)
- Use override to indicate fucntion overrides virtaul function

## Examples:
