### PR TITLE
fix: Add extra labels to implementation name

### DIFF
--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -65,6 +65,9 @@ OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) :
     if(dflv>fMaxDetFlavour) fMaxDetFlavour = dflv;
   }
 
+  if (fCosineZIgnored) fImplementationName += "Linear";
+  fImplementationName += "-" + PMNSType;
+
   std::cout << "PMNS Type : " << PMNSType << std::endl;
   std::cout << "Number of parameters : " << fNOscParams << std::endl;
   std::cout << "Propagation Method : ";


### PR DESCRIPTION
# Pull request description:

Adds description of OscProb types and propagation method to `fImplementationName`

closes #78