### PR TITLE
CUDAProb3 Indexing Fix

### DIFF
--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -127,11 +127,9 @@ void OscProbCalcerCUDAProb3::CalculateProbabilities(const std::vector<FLOAT_T>& 
       // Mapping which links the oscillation channel, neutrino type and energy/cosineZ index to the fWeightArray index
       int IndexToFill = iNuType*fNOscillationChannels*CopyArrSize + iOscChannel*CopyArrSize;
       for (int iOscProb=0;iOscProb<CopyArrSize;iOscProb++) {
-	
 	// Sometimes CUDAProb3 can return *slightly* unphysical oscillation probabilities
 	CopyArr[iOscProb] = CopyArr[iOscProb] > 0.0 ? CopyArr[iOscProb] : 0.0;
 	CopyArr[iOscProb] = CopyArr[iOscProb] < 1.0 ? CopyArr[iOscProb] : 1.0;
-	
 	fWeightArray[IndexToFill+iOscProb] = CopyArr[iOscProb];
       }
     }
@@ -141,7 +139,7 @@ void OscProbCalcerCUDAProb3::CalculateProbabilities(const std::vector<FLOAT_T>& 
 }
 
 int OscProbCalcerCUDAProb3::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex) {
-  int IndexToReturn = NuTypeIndex*fNOscillationChannels*fNCosineZPoints*fNEnergyPoints + OscChanIndex*fNCosineZPoints*fNEnergyPoints + CosineZIndex*fNEnergyPoints + EnergyIndex;
+  int IndexToReturn = NuTypeIndex*fNOscillationChannels*fNCosineZPoints*fNEnergyPoints + OscChanIndex*fNCosineZPoints*fNEnergyPoints + EnergyIndex*fNCosineZPoints + CosineZIndex;
   return IndexToReturn;
 }
 


### PR DESCRIPTION
# Pull request description:
Camille had found several issues with CUDAProb3 (e.g. seeing strange behaviour in downgoing). CUDAProb3 returns the array indexed:
`[E_1 CZ_1, E_1 CZ_2, ... , E_1 CZ_N, E_2 CZ_1, E_2 CZ_2, ... , E_N CZ_N]`
But CUDAProb3 indexing in NuOscillator was returning:
`[E_1 CZ_1, E_2 CZ_1, ... , E_N CZ_1, E_1 CZ_2, E_2 CZ_2, ... , E_N CZ_N]`

Consequently the oscillograms were complete garbage:
![image](https://github.com/user-attachments/assets/0c2391e9-14ac-48be-ae91-7f57e3de52ee)

After changing the index returning in NuOscillator:
![image](https://github.com/user-attachments/assets/41f245ab-453b-41b3-8870-fd1e3bb84fd5)

## Changes or fixes:


## Examples:
