### PR TITLE
Fix CudaProbLinear

### DIFF
--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -33,7 +33,11 @@ jobs:
           - os: Rocky9
             file: Docs/DockerFiles/Rocky9/Dockerfile
             tag: rocky9latest
-            cmakeoptions: -DUseGPU=1
+            cmakeoptions: -DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1
+          - os: Rocky9 CUDAProb3Linear
+            file: Docs/DockerFiles/Rocky9/Dockerfile
+            tag: rocky9latest
+            cmakeoptions: -DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1
 
     name: Build CI ${{ matrix.os }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,10 +80,6 @@ foreach(f ${ALL_Engines})
   cmessage(STATUS "     ${f}: ${Use${f}}")
 endforeach()
 
-if(UseCUDAProb3Linear EQUAL 1 AND UseGPU EQUAL 1)
-  cmessage(FATAL_ERROR "Right now GPU support for CUDAProb3Linear is broken, please use different engine or turn off GPU")
-endif()
-
 cmessage(STATUS "Required variables being used:")
 if(${UseGPU} EQUAL 1)
   cmessage(STATUS "\tUsing GPU")
@@ -200,6 +196,10 @@ if(${UseCUDAProb3Linear} EQUAL 1)
       "GPU_ON ON"
       "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES_STRING}"
     )
+   # KS: This is bit hacky but CUDAProb3Linear is a mess. Whole functions are written in header file
+   # and someone wrote them to be hidden under GPU_ON and wrote shitty cmake which do not propagate this definition.
+   # Therefore NuOscillator is fixing other people mess
+   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE GPU_ON)
   else()
     CPMFindPackage(
       NAME CUDAProb3

--- a/Docs/DockerFiles/Rocky9/Dockerfile
+++ b/Docs/DockerFiles/Rocky9/Dockerfile
@@ -15,6 +15,9 @@ ENV NUOSCILLATOR_VERSION=${NUOSCILLATOR_VERSION:-develop}
 ENV NuOscillator_WORK_DIR=/opt/NuOscillator/
 ENV NuOscillator_INSTALL_DIR=/opt/NuOscillator/build/
 
+ARG CMAKE_OPTIONS="-DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1"
+ENV CMAKE_OPTIONS="$CMAKE_OPTIONS"
+
 RUN mkdir -p ${NuOscillator_WORK_DIR}
 
 WORKDIR /opt/
@@ -25,7 +28,7 @@ RUN git checkout ${NUOSCILLATOR_VERSION}
 
 RUN mkdir -p ${NuOscillator_INSTALL_DIR}
 WORKDIR ${NuOscillator_INSTALL_DIR}
-RUN cmake -DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1 ${NuOscillator_WORK_DIR}
+RUN cmake ${CMAKE_OPTIONS} ${NuOscillator_WORK_DIR}
 RUN make VERBOSE=1 && make install
 
 # KS: Need to set them here, otherwise container using this container will not be able to find NuOscillator


### PR DESCRIPTION
# Pull request description:
Somone did genius move and hide defions under ifdef
https://github.com/mach3-software/CUDAProb3/blob/35b5dbeaf87451efa6b1953591faf91bb3c46e73/atmoscudapropagator.cuh#L23

Code could compile fine. But when icnlduing it compiler couldn't find becasue defiention wasn't progpagted by cmake.
I fixed this in NuOscillator.

## Changes or fixes:


## Examples:
[TimingDistribution.pdf](https://github.com/user-attachments/files/18766673/TimingDistribution.pdf)
![image](https://github.com/user-attachments/assets/340d69aa-3a9c-4bbb-92b0-dc7796eb50ca)


