### PR TITLE
Clang OMP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,12 @@ endif()
 
 if(${UseMultithreading} EQUAL 1)
   target_compile_options(NuOscillatorCompilerOptions INTERFACE -fopenmp)
-  target_link_libraries(NuOscillatorCompilerOptions INTERFACE gomp)
+  # KS: Not a clue why clang need different...
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_link_libraries(NuOscillatorCompilerOptions INTERFACE omp)
+  else()
+    target_link_libraries(NuOscillatorCompilerOptions INTERFACE gomp)
+  endif()
 endif()
 
 if(NOT DEFINED NuOscillator_Compiler_Flags)


### PR DESCRIPTION
# Pull request description:
I am trying to make MaCh3 usable on Mac and this means NuOscillator should be also usable with Clang.
Based on
https://stackoverflow.com/questions/33357029/using-openmp-with-clang

## Changes or fixes:


## Examples:
