### PR TITLE
CudaProb3 Tidy

### DIFF
--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -75,7 +75,7 @@ OscProbCalcerCUDAProb3::OscProbCalcerCUDAProb3(YAML::Node Config_) : OscProbCalc
 }
 
 OscProbCalcerCUDAProb3::~OscProbCalcerCUDAProb3() {
-
+  delete[] CopyArr;
 }
 
 void OscProbCalcerCUDAProb3::SetupPropagator() {
@@ -104,7 +104,11 @@ void OscProbCalcerCUDAProb3::SetupPropagator() {
   propagator->setCosineList(fCosineZArray);
   propagator->setDensityFromFile(EarthDensityFile);
 
-  if (fVerbose >= NuOscillator::INFO) {std::cout << "Setup CUDAProb3 oscillation probability calculater" << std::endl;}
+  if (fVerbose >= NuOscillator::INFO) {std::cout << "Setup CUDAProb3 oscillation probability calculator" << std::endl;}
+
+  // CUDAProb3 calculates oscillation probabilites for each NeutrinoType, so need to copy them from the calculator into fWeightArray
+  CopyArrSize = fNEnergyPoints * fNCosineZPoints;
+  CopyArr = new FLOAT_T[CopyArrSize];
 }
  
 void OscProbCalcerCUDAProb3::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
@@ -135,10 +139,6 @@ void OscProbCalcerCUDAProb3::CalculateProbabilities(const std::vector<FLOAT_T>& 
     ApplyEarthModelSystematics(OscParams);
   }
 
-  // CUDAProb3 calculates oscillation probabilites for each NeutrinoType, so need to copy them from the calculator into fWeightArray
-  int CopyArrSize = fNEnergyPoints * fNCosineZPoints;
-  FLOAT_T* CopyArr = new FLOAT_T[CopyArrSize];
-
   for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
 
     NeutrinoType NuType;
@@ -167,8 +167,6 @@ void OscProbCalcerCUDAProb3::CalculateProbabilities(const std::vector<FLOAT_T>& 
       }
     }
   }
-
-  delete[] CopyArr;
 }
 
 int OscProbCalcerCUDAProb3::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex) {

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.h
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.h
@@ -113,11 +113,6 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
   enum NuType{Nubar=-1, Nu=1};
 
   /**
-   * @brief The name of the config used to setup the particular instance of OscProbCalcerCUDAProb3()
-   */
-  std::string ConfigName;
-
-  /**
    * @brief The mapping of the oscillation channels defined in #fOscillationChannels to the CUDAProb3 constants
    */
   std::vector<int> OscChannels;
@@ -165,6 +160,17 @@ class OscProbCalcerCUDAProb3 : public OscProbCalcerBase {
    * @brief  Number of Earth layers
    */
   int nLayers;
+
+  /**
+   * @brief Size of the array to be copied.
+   */
+  int CopyArrSize;
+
+  /**
+   * @brief Pointer to the array used for copying oscillation probabilities.
+   */
+  FLOAT_T* CopyArr;
+
 };
 
 #endif


### PR DESCRIPTION
# Pull request description:
Now CopyArray stuff is defined once [I don't epxect this should change after SetupPropagator] so might save some time if array is really large

` std::string ConfigName` haven't been used so might as well delete it.

## Changes or fixes:


## Examples:
