### PR TITLE
Fast NuFast

### DIFF
--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -88,11 +88,7 @@ void OscProbCalcerCUDAProb3::SetupPropagator() {
 
   nThreads = 1;
 #if UseMultithreading == 1
-#pragma omp parallel
-  {
-#pragma omp single
-    nThreads = omp_get_num_threads();
-  }
+  nThreads = omp_get_max_threads();
 #endif
 
   if (fVerbose >= NuOscillator::INFO) {std::cout << "Using CPU CUDAProb3 propagator with " << nThreads << " threads" << std::endl;}

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3Linear.cpp
@@ -62,13 +62,9 @@ void OscProbCalcerCUDAProb3Linear::SetupPropagator() {
 #else
 
   nThreads = 1;
-#if UseMultithreading == 1
-#pragma omp parallel
-  {
-#pragma omp single
-    nThreads = omp_get_num_threads();
-  }
-#endif
+  #if UseMultithreading == 1
+  nThreads = omp_get_max_threads();
+  #endif
 
   if (fVerbose >= NuOscillator::INFO) {std::cout << "Using CPU CUDAProb3Linear propagator with fNEnergyPoints:" << fNEnergyPoints << " and:" << nThreads << " threads" << std::endl;}
   propagator = std::unique_ptr< Propagator< FLOAT_T > > ( new BeamCpuPropagator<FLOAT_T>(fNEnergyPoints, nThreads)); // MultiThread CPU propagator

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -48,27 +48,24 @@ void OscProbCalcerNuFASTLinear::SetupPropagator() {
 }
 
 void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
-  double L, E, rho, Ye;
-  double s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31;
-
   // ------------------------------- //
   // Set the experimental parameters //
   // ------------------------------- //
-  L = OscParams[kPATHL]; // km
-  rho = OscParams[kDENS]; // g/cc
-  Ye = OscParams[kELECDENS];
+  const double L = OscParams[kPATHL]; // km
+  const double rho = OscParams[kDENS]; // g/cc
+  const double Ye = OscParams[kELECDENS];
   
   // ------------------------------------- //
   // Set the vacuum oscillation parameters //
   // ------------------------------------- //
-  s12sq = OscParams[kTH12];
-  s13sq = OscParams[kTH13];
-  s23sq = OscParams[kTH23];
-  delta = OscParams[kDCP];
-  Dmsq21 = OscParams[kDM12];
+  const double s12sq = OscParams[kTH12];
+  const double s13sq = OscParams[kTH13];
+  const double s23sq = OscParams[kTH23];
+  const double delta = OscParams[kDCP];
+  const double Dmsq21 = OscParams[kDM12];
 
   //Need to convert OscParams[kDM23] to kDM31
-  Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+  const double Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
   
   // ------------------------------------------ //
   // Calculate all 9 oscillations probabilities //
@@ -80,7 +77,7 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
     for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
       double probs_returned[3][3];
       //+ve energy for neutrinos, -ve energy for antineutrinos
-      E = fEnergyArray[iOscProb] * fNeutrinoTypes[iNuType];
+      const double E = fEnergyArray[iOscProb] * fNeutrinoTypes[iNuType];
 
       Probability_Matter_LBL(s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31, L, E, rho, Ye, N_Newton, &probs_returned);
 
@@ -89,9 +86,9 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
       #endif
       for (int iOscChannel=0;iOscChannel<fNOscillationChannels;iOscChannel++) {
         // Mapping which links the oscillation channel, neutrino type and energy index to the fWeightArray index
-        int IndexToFill = iNuType*fNOscillationChannels*fNEnergyPoints + iOscChannel*fNEnergyPoints;
+        const int IndexToFill = iNuType*fNOscillationChannels*fNEnergyPoints + iOscChannel*fNEnergyPoints;
 
-        double Weight = probs_returned[fOscillationChannels[iOscChannel].GeneratedFlavour-1][fOscillationChannels[iOscChannel].DetectedFlavour-1];
+        const double Weight = probs_returned[fOscillationChannels[iOscChannel].GeneratedFlavour-1][fOscillationChannels[iOscChannel].DetectedFlavour-1];
         fWeightArray[IndexToFill+iOscProb] = Weight;
       }
       

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -4,6 +4,10 @@
 
 #include "c++/NuFast.cpp"
 
+#if UseMultithreading == 1
+#include "omp.h"
+#endif
+
 OscProbCalcerNuFASTLinear::OscProbCalcerNuFASTLinear(YAML::Node Config_) : OscProbCalcerBase(Config_)
 {
   //=======
@@ -21,14 +25,17 @@ OscProbCalcerNuFASTLinear::OscProbCalcerNuFASTLinear(YAML::Node Config_) : OscPr
   }
   
   //=======
-
   fNOscParams = kNOscParams;
 
   fNNeutrinoTypes = 2;
   InitialiseNeutrinoTypesArray(fNNeutrinoTypes);
   fNeutrinoTypes[0] = Nu;
   fNeutrinoTypes[1] = Nubar;
-
+  #if UseMultithreading == 1
+  fImplementationName += "-CPU-"+std::to_string(omp_get_max_threads());
+  #else
+  fImplementationName += "-CPU-"+std::to_string(1);
+  #endif
   // This implementation only considers linear propagation, thus no requirement to set cosineZ array
   IgnoreCosineZBinning(true);
 }
@@ -41,7 +48,7 @@ void OscProbCalcerNuFASTLinear::SetupPropagator() {
 }
 
 void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
-  double L, E, rho, Ye, probs_returned[3][3];
+  double L, E, rho, Ye;
   double s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31;
 
   // ------------------------------- //
@@ -64,23 +71,28 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
   Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
   
   // ------------------------------------------ //
-  // Calculate all 9 oscillationa probabilities //
+  // Calculate all 9 oscillations probabilities //
   // ------------------------------------------ //
-
+  #if UseMultithreading == 1
+  #pragma omp parallel for collapse(2)
+  #endif
   for (int iOscProb=0;iOscProb<fNEnergyPoints;iOscProb++) {
     for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
-      
+      double probs_returned[3][3];
       //+ve energy for neutrinos, -ve energy for antineutrinos
       E = fEnergyArray[iOscProb] * fNeutrinoTypes[iNuType];
 
       Probability_Matter_LBL(s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31, L, E, rho, Ye, N_Newton, &probs_returned);
 
+      #if UseMultithreading == 1
+      #pragma omp simd
+      #endif
       for (int iOscChannel=0;iOscChannel<fNOscillationChannels;iOscChannel++) {
-	// Mapping which links the oscillation channel, neutrino type and energy index to the fWeightArray index
-	int IndexToFill = iNuType*fNOscillationChannels*fNEnergyPoints + iOscChannel*fNEnergyPoints;
+        // Mapping which links the oscillation channel, neutrino type and energy index to the fWeightArray index
+        int IndexToFill = iNuType*fNOscillationChannels*fNEnergyPoints + iOscChannel*fNEnergyPoints;
 
-	double Weight = probs_returned[fOscillationChannels[iOscChannel].GeneratedFlavour-1][fOscillationChannels[iOscChannel].DetectedFlavour-1];
-	fWeightArray[IndexToFill+iOscProb] = Weight;
+        double Weight = probs_returned[fOscillationChannels[iOscChannel].GeneratedFlavour-1][fOscillationChannels[iOscChannel].DetectedFlavour-1];
+        fWeightArray[IndexToFill+iOscProb] = Weight;
       }
       
     }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ source Linux/bin/setup.NuOscillator.sh
 then you can check if everything runs correctly by
 ```bash
 cd ../
-./build/Linux/bin/DragRace
+./build/Linux/bin/DragRace 1000 NuOscillatorConfigs/Binned_NuFASTLinear.yaml
 ```
 
 ## How to Integrate in Framework


### PR DESCRIPTION
# Pull request description:
Implement Mulithreading to NuFast this allowed to  make it at least twice faster.

Before: 0.030 milisecond
4 CPU:  0.020 mILI
8 CPI: 0.016 MILI

This is USING **50 Energy points**. T2K uses ~300 bins.

If we move to Unbinned (1001 Energy points) it scales very well

2 CPU: 0.71 MILI
4 CPU: 0.54 MILI
8 CPU:  0.40 MILI

omp_get_num_threads() returns threads in parraler region while omp_get_max_threads() available threads (max or output of OMP_NUM_THREADS) using later is better as doesn't reuiwer stuipid omp single etc.

## Changes or fixes:


## Examples:
![before](https://github.com/user-attachments/assets/6549076d-912b-4e7d-bee5-71a37d7a7dda)
<img width="835" alt="After4thrreads" src="https://github.com/user-attachments/assets/9892cee9-2d31-48e8-aa8c-467e9c9b83b2" />
![after8Threads](https://github.com/user-attachments/assets/f5595c5f-0967-4ad3-8e0a-1a7ea2b361a1)
