### PR TITLE
Prbo3++ Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ endif()
 if(${UseCUDAProb3Linear} EQUAL 1)
   if(${UseGPU} EQUAL 1)
     CPMFindPackage(
-      NAME CUDAProb3
+      NAME CUDAProb3Linear
       GITHUB_REPOSITORY "mach3-software/CUDAProb3"
       GIT_TAG "main"
       OPTIONS
@@ -216,7 +216,7 @@ if(${UseCUDAProb3Linear} EQUAL 1)
    target_compile_definitions(NuOscillatorCompilerOptions INTERFACE GPU_ON)
   else()
     CPMFindPackage(
-      NAME CUDAProb3
+      NAME CUDAProb3Linear
       GITHUB_REPOSITORY "mach3-software/CUDAProb3"
       GIT_TAG "main"
       OPTIONS
@@ -263,6 +263,9 @@ if(${UseProb3ppLinear} EQUAL 1)
   if(NOT TARGET Prob3plusplus)
     cmessage(FATAL_ERROR "Could not find Prob3plusplus")
   endif()
+
+  # KS: Add additional compilation flags to be used for Prob3++
+  target_compile_options(Prob3plusplus PRIVATE ${NuOscillator_Compiler_Flags})
   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseProb3ppLinear=1)
   
   install(TARGETS Prob3plusplus


### PR DESCRIPTION
# Pull request description:
By Default Prob3++ compiles with O2 optimisation.

If somone defines NuOscillator to use O3 flag then this flag nomrally would not be propagated to Prob3++ :(

This is what this PR changes. NuOsc flags will be propagated to Prob3++

Prob3++
By default:: 0.49
Wiht O3 (Test 1): 0.45
+Fast math and inline ALL (Test 2): 0.41

All plots with compilation and speed can be found below but clearly only adding compilation flags helped speed up Prob3++ :)

## Changes or fixes:


## Examples:
![before](https://github.com/user-attachments/assets/b24dfee5-3b41-4914-ab62-c8e6ee2bac68)

Test 1
![Optimisation_Test1](https://github.com/user-attachments/assets/d914367d-e87f-4856-9560-0fbb103a1508)
![test_1](https://github.com/user-attachments/assets/324f0287-2f48-4332-91f1-d5d71016deb0)

Test 2
![setting_2](https://github.com/user-attachments/assets/c873bb01-5dc0-4f23-84f6-ccff165bd5be)
![test_2](https://github.com/user-attachments/assets/a4422f0e-3e51-40ca-b021-5e79c9a96b10)
