### PR TITLE
Pointless NuFast Speed Up

### DIFF
--- a/OscProbCalcer/OscProbCalcerBase.cpp
+++ b/OscProbCalcer/OscProbCalcerBase.cpp
@@ -306,6 +306,11 @@ void OscProbCalcerBase::Reweight(const std::vector<FLOAT_T>& OscParams) {
 }
 
 void OscProbCalcerBase::SanitiseProbabilities() {
+
+  // Precompute these here
+  const double lower_limit = -1.0*PrecisionLimit;
+  const double upper_limit = 1.0 + PrecisionLimit;
+
   for (int iWeight=0;iWeight<fNWeights;++iWeight) {
     if (std::isnan(fWeightArray[iWeight])) {
       std::cerr << "Found nan probability in fWeightArray" << std::endl;
@@ -313,29 +318,28 @@ void OscProbCalcerBase::SanitiseProbabilities() {
       throw std::runtime_error("Invalid probability");
     }
 
-
     if ((fWeightArray[iWeight] >= 0.0) && (fWeightArray[iWeight] <= 1.0)) {
       //Check if it's between 0.0 and 1.0, if so continue to next event
       continue;
     }
-    if (fWeightArray[iWeight] < -1.0*PrecisionLimit) {
+    if (fWeightArray[iWeight] < lower_limit) {
       //Check if it's below 0.0-PrecisionLimit
       std::cerr << "Found probability which is below the allowable precision of: 0.0-" << PrecisionLimit << std::endl;
       std::cerr << "iWeight:" << iWeight << std::endl;
       std::cerr << "fWeightArray[iWeight]:" << fWeightArray[iWeight] << std::endl;
       throw std::runtime_error("Probability below zero");
     }
-    if ((fWeightArray[iWeight] > -1.0*PrecisionLimit) && (fWeightArray[iWeight] < 0)) {
+    if ((fWeightArray[iWeight] > lower_limit) && (fWeightArray[iWeight] < 0)) {
       //Check if it's just below 0 (within some precision) and set to 0 if it is
       fWeightArray[iWeight] = 0.;
       continue;
     }
-    if ((fWeightArray[iWeight] > 1.0) && (fWeightArray[iWeight] < (1.0+PrecisionLimit))) {
+    if ((fWeightArray[iWeight] > 1.0) && (fWeightArray[iWeight] < (upper_limit))) {
       //Check if it's just above 1 (within some precision) and set to 1 if it is
       fWeightArray[iWeight] = 1.;
       continue;
     }
-    if (fWeightArray[iWeight] > (1.0+PrecisionLimit)) {
+    if (fWeightArray[iWeight] > (upper_limit)) {
       //Check if it's above 1.0+PrecisionLimit
       std::cerr << "Found probability which is above the allowable precision of: 1.0+" << PrecisionLimit << std::endl;
       std::cerr << "iWeight:" << iWeight << std::endl;

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -67,11 +67,12 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
   //Need to convert OscParams[kDM23] to kDM31
   const double Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
   
+  double probs_returned[3][3];
   // ------------------------------------------ //
   // Calculate all 9 oscillations probabilities //
   // ------------------------------------------ //
   #if UseMultithreading == 1
-  #pragma omp parallel for collapse(2)
+  #pragma omp parallel for collapse(2) private(probs_returned)
   #endif
   for (int iOscProb=0;iOscProb<fNEnergyPoints;iOscProb++) {
     for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
@@ -91,7 +92,6 @@ void OscProbCalcerNuFASTLinear::CalculateProbabilities(const std::vector<FLOAT_T
         const double Weight = probs_returned[fOscillationChannels[iOscChannel].GeneratedFlavour-1][fOscillationChannels[iOscChannel].DetectedFlavour-1];
         fWeightArray[IndexToFill+iOscProb] = Weight;
       }
-      
     }
   }
 


### PR DESCRIPTION
# Pull request description:
Minor Speedup of NuFast

## Changes or fixes:

- Precompute precision values to not do this every single weight
- now probs_returned is private, meaning each thread has it's own copy. Thanks to this it doesn't have to be intialised each energy iteration. This is small array so it's fast thus impact is minor

## Examples:
Impact is tiny thus difficutl to report speed as there are msolty flcutioations thus I provide ranges
Binned 
old: 0.016 - 0.021
new 0.016 - 0.018

Unbinned
old 0.27 - 0.29
new 0.26 - 0.28

overall there are smaller fluctuations which should results in more consistent speed