### PR TITLE
feat: Minor OscProb SpeedUp

### DIFF
--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -165,12 +165,15 @@ void OscProbCalcerOscProb::CalcProbPMNS(const std::vector<FLOAT_T>& OscParams) {
                                                            fMaxDetFlavour,
                                                            fEnergyArray[iEnergy]);
 
+        #if UseMultithreading == 1
+        #pragma omp simd
+        #endif
         for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
 
-          int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour-1;
-          int dflv = fOscillationChannels[iOscChannel].DetectedFlavour-1;
-          double weight = probMatrix[gflv][dflv];
-          int index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
+          const int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour-1;
+          const int dflv = fOscillationChannels[iOscChannel].DetectedFlavour-1;
+          const double weight = probMatrix[gflv][dflv];
+          const int index = ReturnWeightArrayIndex(iNuType, iOscChannel, iEnergy, iCosineZ);
 
           fWeightArray[index] = weight;
 
@@ -341,7 +344,7 @@ void OscProbCalcerOscProb::SetPMNSParams(const std::vector<FLOAT_T>& OscParams) 
 
 }
 
-int OscProbCalcerOscProb::PMNS_StrToInt(std::string PMNSType) {
+int OscProbCalcerOscProb::PMNS_StrToInt(const std::string& PMNSType) {
 
   if (PMNSType == "Fast" || PMNSType == "fast")          return kFast;
   if (PMNSType == "Sterile+1" || PMNSType == "Sterile1") return kPMNSSterile1;

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -104,7 +104,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    *
    * @return Enum value describing the PMNS Matrix to use
    */
-  int PMNS_StrToInt(std::string PMNSType);
+  int PMNS_StrToInt(const std::string& PMNSType);
 
   /**
    * @brief Return number of parameters needed for a particular type of PMNS matrix


### PR DESCRIPTION
# Pull request description:
Use SIMD to introduce minor speed of around 2-5% to OscProb

## Changes or fixes:


## Examples:
Before
<img width="983" alt="before" src="https://github.com/user-attachments/assets/ec936734-a321-41cb-94ea-e59564a5eaa7" />

after
![after](https://github.com/user-attachments/assets/85d716a2-d7ea-4f52-9105-e4aed5bdf4b8)
