### PR TITLE
feat: Universal setup: bash, sh, zsh, ksh, dash

### DIFF
--- a/cmake/Templates/setup.NuOscillator.sh.in
+++ b/cmake/Templates/setup.NuOscillator.sh.in
@@ -1,15 +1,22 @@
+# TN: This shebang is rather useless, since I guess the user needs to "source" the setup,
+# not execute it. Executing it from a different shell than bash would only open bash, run
+# the script and close the bash with no changes in the PATHs of the original shell. That is,
+# nothing gets set up. If the script is sourced, the shebang is skipped and the script is sourced
+# from the original shell (not bash).
+# Anyway, I will keep it here, if there is some use to it I am missing.
 #!/bin/bash
 
 if ! type add_to_PATH &> /dev/null; then
 
 ### Adapted from https://unix.stackexchange.com/questions/4965/keep-duplicates-out-of-path-on-source
-function add_to_PATH () {
+add_to_PATH()
+{
   for d; do
 
-    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+    d=$( cd -- $d && { pwd -P || pwd; } ) 2>/dev/null  # canonicalize symbolic links
+    if [[ -z $d ]]; then continue; fi  # skip nonexistent directory
 
-    if [ "$d" == "/usr/bin" ] || [ "$d" == "/usr/bin64" ] || [ "$d" == "/usr/local/bin" ] || [ "$d" == "/usr/local/bin64" ]; then
+    if [[ $d == "/usr/bin" || $d == "/usr/bin64" || $d == "/usr/local/bin" || $d == "/usr/local/bin64" ]]; then
       case ":$PATH:" in
         *":$d:"*) :;;
         *) export PATH=$PATH:$d;;
@@ -27,13 +34,14 @@ fi
 
 if ! type add_to_LD_LIBRARY_PATH &> /dev/null; then
 
-function add_to_LD_LIBRARY_PATH () {
+add_to_LD_LIBRARY_PATH()
+{
   for d; do
 
-    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
-    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+    d=$( cd -- $d && { pwd -P || pwd; } ) 2>/dev/null  # canonicalize symbolic links
+    if [[ -z $d ]]; then continue; fi  # skip nonexistent directory
 
-    if [ "$d" == "/usr/lib" ] || [ "$d" == "/usr/lib64" ] || [ "$d" == "/usr/local/lib" ] || [ "$d" == "/usr/local/lib64" ]; then
+    if [[ $d == "/usr/bin" || $d == "/usr/bin64" || $d == "/usr/local/bin" || $d == "/usr/local/bin64" ]]; then
       case ":$LD_LIBRARY_PATH:" in
         *":$d:"*) :;;
         *) export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d;;
@@ -49,15 +57,24 @@ function add_to_LD_LIBRARY_PATH () {
 
 fi
 
-#if it was sourced as . setup.sh then you can't scrub off the end... assume that
-#we are in the correct directory.
-if ! echo "${BASH_SOURCE}" | grep "/" --silent; then
-  SETUPDIR=$(readlink -f ${PWD}/..)
-else
-  SETUPDIR=$(readlink -f ${BASH_SOURCE%/*}/..)
-fi
+# TN: this is one of the most stable implementation of getting the
+# path to the script being called (and hence the path to the $NUOSCILLATOR_ROOT/bin)
+# I have seen so far. This can be called from anywhere and with
+# both source or ., with relative or absolute paths.
+pushd . > '/dev/null';
+SCRIPT_PATH="${BASH_SOURCE[0]:-$0}";
 
-export NUOSCILLATOR_ROOT=${SETUPDIR}
+while [[ -h "$SCRIPT_PATH" ]];
+do
+    cd "$( dirname -- "$SCRIPT_PATH"; )";
+    SCRIPT_PATH="$( readlink -f -- "$SCRIPT_PATH"; )";
+done
+
+cd "$( dirname -- "$SCRIPT_PATH"; )" > '/dev/null';
+SCRIPT_PATH="$( pwd; )";
+popd  > '/dev/null';
+
+export NUOSCILLATOR_ROOT=${SCRIPT_PATH}/..
 export NUOSCILLATOR_VERSION=@NUOSCILLATOR_VERSION@
 export CUDAProb3_DIR=@CUDAProb3_SOURCE_DIR@
 
@@ -68,4 +85,4 @@ add_to_LD_LIBRARY_PATH @SQUIDS_LIB_DIR@
 add_to_LD_LIBRARY_PATH @NUSQUIDS_LIB_DIR@
 add_to_LD_LIBRARY_PATH @OSCPROB_LIB_DIR@
 
-unset SETUPDIR
+unset SCRIPT_PATH


### PR DESCRIPTION
# Pull request description:

Trying to edit the setup functions to be portable and sourceable across different unix shells. I tested this version with bash, sh, zsh, ksh, and dash. This script can be sourced from anywhere, independent on your current $(pwd).

Unfortunately, this is cannot be sourced in csh and tcsh shells. Likely a specific script is needed (though I hope nobody's been using csh).

## Changes or fixes:

1) Switching to the enhanced bash c++-like syntax ```[[ ]],  ==```, etc., which is available in most modern versions of unix shells (unlike combinations of bash extension with POSIX statements) and making it consistent in the setup scripts.
2) ```function function_name () {}``` is also a mixture of several definition practices interpreted correctly in bash only. The edited way is accessible from all bash, zsh, ksh, and dash shells.
3) Keep spaces from within the parentheses ```$( )```.

## Examples:
