### PR TITLE
Fix cmake and use version cotnrol for Prob3++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ if(NOT DEFINED CUDAProb3Linear_BRANCH)
 endif()
 
 if(NOT DEFINED Prob3ppLinear_BRANCH)
-  set(Prob3ppLinear_BRANCH "main")
+  # KS: Let's use commit because Prob3++ has no tags...
+  set(Prob3ppLinear_BRANCH "fa103b1e57fbbe54ac496255adacc703b656edc6")
 endif()
 
 if(NOT DEFINED ProbGPULinear_BRANCH)

--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -2,7 +2,7 @@ set(HEADERS OscProbCalcerBase.h OscProbCalcerFactory.h)
 
 add_library(OscProbCalcer SHARED OscProbCalcerBase.cpp OscProbCalcerFactory.cpp)
 
-target_link_libraries(OscProbCalcer yaml-cpp NuOscillatorCompilerOptions ROOT::Core)
+target_link_libraries(OscProbCalcer yaml-cpp NuOscillatorCompilerOptions ROOT::Core ROOT::Hist)
 
 target_include_directories(OscProbCalcer PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>


### PR DESCRIPTION
# Pull request description:

## Changes or fixes:
- I was having comoilation error on one of clusters so had to add link lib
- Let's use commit for prob3++. I tried contaicting Roger to make a tag but he didn't reply yet [once he makes tag we shal update]

## Examples:
![blarb](https://github.com/user-attachments/assets/e0bbe6da-de55-44cb-8b59-fcce736d5d23)
