### PR TITLE
ROOT I/O tweaks

### DIFF
--- a/Constants/OscillatorConstants.h
+++ b/Constants/OscillatorConstants.h
@@ -359,7 +359,7 @@ inline std::vector<FLOAT_T> ReadBinEdgesFromFile(std::string TFileName, std::str
     BinEdges[iBin] = Histogram->GetBinLowEdge(iBin+1);
   }
 
-  delete Histogram;
+  File->Close();
   delete File;
 
   if (Verbose >= NuOscillator::INFO) {

--- a/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
+++ b/OscProbCalcer/OscProbCalcer_CUDAProb3.cpp
@@ -284,6 +284,9 @@ void OscProbCalcerCUDAProb3::SetProductionHeightsAveraging(){
   propagator->SetNumberOfProductionHeightBinsForAveraging(NProductionHeightAveragingBins);
   propagator->setProductionHeightList(ProductionHeightProbabilitiesList,ProductionHeightsList);
   
+  File->Close();
+  delete File;
+
   if (fVerbose >= NuOscillator::INFO){std::cout<<"Completed SetProductionHeightsAveraging()"<<std::endl;}
 }
 


### PR DESCRIPTION
# Pull request description:
In OscProbCalcer_CUDAProb3 we weren't closing TFile which could cause memory leak for TH3 histograms :(

In OscillatorConstants.h I removed delete hsitogram as it was causing segfault...
This is ROOT version depdenant as using 6.26/10 works fine while issue appears in 6.24/08

Anyway issue is that histograms is managed by ROOT memory maangment so if you delete it and later Close file it tries to delete again...

I don't think this fixes introucce memeory leaks as ROOT crappy memory managment should take care of it...

## Changes or fixes:


## Examples:
