### PR TITLE
Update CMakeLists.txt to new NuFast-LBL repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,7 @@ if(${UseNuFASTLinear} EQUAL 1)
   CPMAddPackage(
     NAME NuFAST
     GIT_TAG ${NuFASTLinear_BRANCH}
-    GITHUB_REPOSITORY PeterDenton/NuFast
+    GITHUB_REPOSITORY PeterDenton/NuFast-LBL
     DOWNLOAD_ONLY
   )
   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseNuFASTLinear=1)


### PR DESCRIPTION
I changed the name of the NuFast repo to NuFast-LBL. For now github will automatically redirect, but cmake should eventually update.