### PR TITLE
feat: Crackpot SpeedUp for SubSampling

### DIFF
--- a/Oscillator/OscillatorSubSampling.cpp
+++ b/Oscillator/OscillatorSubSampling.cpp
@@ -131,7 +131,7 @@ void OscillatorSubSampling::SetupOscillatorImplementation() {
 
   for (size_t iBin = 0; iBin < AveragedOscillationProbabilities.size(); iBin++) {
     if (OscillationProbabilitiesToAverage[iBin].size() == 0) {
-      std::cerr << "Division by zero encountered in "<<__FILE__<<" at bin number: " << iBin
+      std::cerr << "Found bin with zero components to average "<<__FILE__<<" at bin number: " << iBin
       << " in function: " << __func__ << std::endl;
       throw std::runtime_error("Fatal error in " + std::string(__func__) +
       ": Division by zero at bin number " + std::to_string(iBin));


### PR DESCRIPTION
# Pull request description:
Several minor imrpvmnets to increase perofmance of sub sampling.
Config use:
[CUDAProb3_SubSampling_ProdHAvg_EarthSysts.txt](https://github.com/user-attachments/files/21685619/CUDAProb3_SubSampling_ProdHAvg_EarthSysts.txt)


## Changes or fixes:


## Examples:
before = default
no if = removing sanity check to not divide by 0 [moved into setup]
+omp = inclusion of multihreading
+reference = tl:dr const auto& Probabilities = OscillationProbabilitiesToAverage[iBin]; thanks to this we store local variable rather than doing memory search.
<img width="758" height="393" alt="image" src="https://github.com/user-attachments/assets/b505b89a-dbef-485a-908b-99990a5133ce" />
