### PR TITLE
bugfix: Add the ROOT::Tree target into OscProbCalcer/CMakeLists.txt

### DIFF
--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -2,7 +2,7 @@ set(HEADERS OscProbCalcerBase.h OscProbCalcerFactory.h)
 
 add_library(OscProbCalcer SHARED OscProbCalcerBase.cpp OscProbCalcerFactory.cpp)
 
-target_link_libraries(OscProbCalcer yaml-cpp NuOscillatorCompilerOptions ROOT::Core ROOT::Hist)
+target_link_libraries(OscProbCalcer yaml-cpp NuOscillatorCompilerOptions ROOT::Core ROOT::Hist ROOT::Tree)
 
 target_include_directories(OscProbCalcer PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/../>


### PR DESCRIPTION
# Pull request description:
Addresses: https://github.com/dbarrow257/NuOscillator/issues/135

## Changes or fixes:


## Examples:
