### PR TITLE
feat: Option to not sanitise oscillation probabilities

### DIFF
--- a/OscProbCalcer/OscProbCalcerBase.cpp
+++ b/OscProbCalcer/OscProbCalcerBase.cpp
@@ -66,6 +66,21 @@ OscProbCalcerBase::OscProbCalcerBase(YAML::Node InputConfig_) {
     throw std::runtime_error("Invalid setup");
   }
   InitialiseOscillationChannelMapping();
+
+  fNoSanity = false;
+  if (Config["OscProbCalcerSetup"]["NoSanity"]) {
+    fNoSanity = Config["OscProbCalcerSetup"]["NoSanity"].as<bool>();
+    if (fNoSanity) {
+      std::cout << "=================================== WARNING ===================================" << std::endl;
+      std::cout << "User specified that NoSanity should be applied -" << std::endl;
+      std::cout << "This means that oscillation probabilities returned from the engine are not" << std::endl;
+      std::cout << "checked to be within the strict [0,1] bound." << std::endl;
+      std::cout << "This should only be used in performance sensitive applications and only where" << std::endl;
+      std::cout << "the engine has been throughly checked for your application." << std::endl;
+      std::cout << "Standard recommendation is to not run in this mode!" << std::endl;
+      std::cout << "===============================================================================" << std::endl;
+    }
+  }
 }
 
 OscProbCalcerBase::~OscProbCalcerBase() {
@@ -301,7 +316,7 @@ void OscProbCalcerBase::Reweight(const std::vector<FLOAT_T>& OscParams) {
   SetCurrOscParams(OscParams);
 
   CalculateProbabilities(OscParams);
-  SanitiseProbabilities();
+  if (!fNoSanity) {SanitiseProbabilities();}
   if (fVerbose >= NuOscillator::INFO) {std::cout << "Implementation:" << fImplementationName << " completed reweight and was found to have sensible oscillation weights" << std::endl;}
 }
 

--- a/OscProbCalcer/OscProbCalcerBase.h
+++ b/OscProbCalcer/OscProbCalcerBase.h
@@ -495,6 +495,11 @@ class OscProbCalcerBase {
    * @brief Precision limit which allows a slight unphysical probability to pass the SanitiseProbabilities check
    */
   FLOAT_T PrecisionLimit;
+
+  /**
+   * @brief Boolean declaring whether the SanitiseProbabilities function should be called in the Reweight function. This should only be used for performance sensitive applications as when this is false, oscillation probabilities could be returned which are <0, >1, or nan 
+   */
+  bool fNoSanity;
 };
 
 #endif


### PR DESCRIPTION
Add option to allow the sanitisation to be removed from the OscProbCalcerBase::Reweight function

# Pull request description:


## Changes or fixes:


## Examples:
