### PR TITLE
New Engine: NuFAST-Earth

### DIFF
--- a/.github/workflows/CDImage.yml
+++ b/.github/workflows/CDImage.yml
@@ -22,7 +22,7 @@ jobs:
           - os: alma9
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag_latest: alma9latest
-            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1
+            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1
 
 
     name: Image CD ${{ matrix.os }}

--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -21,23 +21,23 @@ jobs:
           - os: Alma9
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag: alma9latest
-            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
           - os: Alma9 float
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag: alma9latest
-            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseCHICLinear=1
           - os: Alma9 w/o multithread
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag: alma9latest
-            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=0 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=0 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
           - os: Rocky9
             file: Docs/DockerFiles/Rocky9/Dockerfile
             tag: rocky9latest
-            cmakeoptions: -DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseGPU=1 -DUseMultithreading=1 -DUseDoubles=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTEarth=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=1 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
           - os: Fedora32
             file: Docs/DockerFiles/Fedora32/Dockerfile
             tag: fedora32latest
-            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseProbGPULinear=0 -DUseOscProb=0 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1
+            cmakeoptions: -DUseDoubles=1 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=0 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1
 
 
     name: Build CI ${{ matrix.os }}

--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -25,11 +25,11 @@ jobs:
           - os: Alma9 float
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag: alma9latest
-            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=1 -DUseCUDAProb3=1 -DUseCUDAProb3Linear=1 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=0 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseCHICLinear=1
           - os: Alma9 w/o multithread
             file: Docs/DockerFiles/Alma9/Dockerfile
             tag: alma9latest
-            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=0 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=1 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
+            cmakeoptions: -DUseDoubles=0 -DUseMultithreading=0 -DUseCUDAProb3=0 -DUseCUDAProb3Linear=0 -DUseProb3ppLinear=1 -DUseNuFASTLinear=1 -DUseNuFASTEarth=0 -DUseProbGPULinear=0 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
           - os: Rocky9
             file: Docs/DockerFiles/Rocky9/Dockerfile
             tag: rocky9latest

--- a/.github/workflows/CIValidations.yml
+++ b/.github/workflows/CIValidations.yml
@@ -22,13 +22,13 @@ jobs:
       matrix:
         include:
           - name: DragRace_Atm_Binned
-            cmake_options: -DUseCUDAProb3=1 -DUseOscProb=1
+            cmake_options: -DUseCUDAProb3=1 -DUseOscProb=1 -DUseNuFASTEarth=1
             exec: DragRace
-            argument: 10 NuOscillatorConfigs/Binned_CUDAProb3.yaml NuOscillatorConfigs/Binned_OscProb.yaml
+            argument: 10 NuOscillatorConfigs/Binned_CUDAProb3.yaml NuOscillatorConfigs/Binned_OscProb.yaml NuOscillatorConfigs/Binned_NuFASTEarth.yaml
           - name: DragRace_Atm_Unbinned
-            cmake_options: -DUseCUDAProb3=1 -DUseOscProb=1
+            cmake_options: -DUseCUDAProb3=1 -DUseOscProb=1 -DUseNuFASTEarth=1
             exec: DragRace
-            argument: 10 NuOscillatorConfigs/Unbinned_CUDAProb3.yaml NuOscillatorConfigs/Unbinned_OscProb.yaml
+            argument: 10 NuOscillatorConfigs/Unbinned_CUDAProb3.yaml NuOscillatorConfigs/Unbinned_OscProb.yaml NuOscillatorConfigs/Unbinned_NuFASTEarth.yaml
           - name: DragRace_Linear_Binned
             cmake_options: -DUseCUDAProb3Linear=1 -DUseNuFASTLinear=1 -DUseProb3ppLinear=1 -DUseOscProb=1 -DUseNuSQUIDSLinear=1 -DUseGLoBESLinear=1 -DUseCHICLinear=1
             exec: DragRace

--- a/.github/workflows/CIValidations2.yml
+++ b/.github/workflows/CIValidations2.yml
@@ -32,7 +32,7 @@ jobs:
             exec: SingleOscProbCalcer
             argument: NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
             new_output: NuFASTEarth_New.txt
-            old_output: NuFASTEarth_Stored.txt	    
+            old_output: NuFASTEarth_Stored.txt
           - name: OscProbCalcer OscProbLinear Comparison
             cmake_options: -DUseOscProb=1
             exec: SingleOscProbCalcer

--- a/.github/workflows/CIValidations2.yml
+++ b/.github/workflows/CIValidations2.yml
@@ -27,6 +27,12 @@ jobs:
             argument: NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTLinear.yaml
             new_output: NuFASTLinear_New.txt
             old_output: NuFASTLinear_Stored.txt
+          - name: OscProbCalcer NuFASTEarth Comparison
+            cmake_options: -DUseNuFASTEarth=1
+            exec: SingleOscProbCalcer
+            argument: NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
+            new_output: NuFASTEarth_New.txt
+            old_output: NuFASTEarth_Stored.txt	    
           - name: OscProbCalcer OscProbLinear Comparison
             cmake_options: -DUseOscProb=1
             exec: SingleOscProbCalcer

--- a/Apps/Analysis.cpp
+++ b/Apps/Analysis.cpp
@@ -48,7 +48,7 @@ int main() {
       Oscillator->SetEnergyArrayInCalcer(EnergyArray);
 	
 	//Check if we also need to set the CosineZ binning
-	if (!Oscillator->CosineZIgnored()) {
+	if (!Oscillator->ReturnCosineZIgnored()) {
 	  Oscillator->SetCosineZArrayInCalcer(CosineZArray);
 	}
     }

--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -6,6 +6,7 @@ foreach(app
         SingleOscillator
         SingleOscProbCalcer
 	OscProbCalcerComparison
+	CompareOscillationProbabilities
 	MakeExampleBinning
       )
 

--- a/Apps/CompareOscillationProbabilities.cpp
+++ b/Apps/CompareOscillationProbabilities.cpp
@@ -1,0 +1,266 @@
+#include "Oscillator/OscillatorFactory.h"
+
+#include "Constants/OscillatorConstants.h"
+
+#include <iostream>
+#include <iomanip>
+#include <math.h>
+#include <chrono>
+
+#include "TGraph.h"
+#include "TCanvas.h"
+#include "TPad.h"
+#include "TLegend.h"
+#include "TLatex.h"
+
+using std::chrono::high_resolution_clock;
+using std::chrono::duration_cast;
+using std::chrono::duration;
+using std::chrono::milliseconds;
+
+int main(int argc, char **argv) {
+  std::string FileExt = ".png";
+  
+  //============================================================================================================
+  std::vector<FLOAT_T> EnergyArray = logspace(0.1,10.,1e3);
+  std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
+
+  std::vector<FLOAT_T> OscParams_Basic = ReturnOscParams_Basic();
+  std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
+  std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe = ReturnOscParams_Beam_wYe();
+  std::vector<FLOAT_T> OscParams_Beam_wYe_wDeco = ReturnOscParams_Beam_wYe_wDeco();
+  std::vector<FLOAT_T> OscParams_Beam_wYe_wLIV = ReturnOscParams_Beam_wYe_wLIV();
+  std::vector<FLOAT_T> OscParams_Beam_wYe_wNSI = ReturnOscParams_Beam_wYe_wNSI();
+  
+  std::cout << "========================================================" << std::endl;
+  std::cout << "Starting setup in executable" << std::endl;
+
+  std::vector<OscillatorBase*> Oscillators;
+  OscillatorFactory* OscFactory = new OscillatorFactory();
+  OscillatorBase* Oscillator;
+
+  //Get the standard set of config names or use what is provided from the arguments
+  std::vector<std::string> ConfigNames;
+  if (argc == 1) {
+    ConfigNames = ReturnKnownConfigs();
+  } else {
+    for (int i=1;i<argc;i++) {
+      ConfigNames.push_back(argv[i]);
+    }
+  }
+
+  std::cout << "========================================================" << std::endl;
+  std::cout << "Setting up Oscillators" << std::endl;
+  
+  for (size_t iConfig=0;iConfig<ConfigNames.size();iConfig++) {
+    std::cout << "========================================================" << std::endl;
+    std::cout << "Initialising " << ConfigNames[iConfig] << std::endl;
+
+    //Create OscillatorBase* object from YAML config
+    Oscillator = OscFactory->CreateOscillator(ConfigNames[iConfig]);
+
+    //Check if the Energy and CosineZ evaluation points have been set in the constructor of the object (i.e. Binned where the templates have been picked up by the constructor)
+    //or if we need to set them after the fact (i.e. unbinned where the points may change depending on the events etc.)
+    if (!Oscillator->EvalPointsSetInConstructor()) {
+      Oscillator->SetEnergyArrayInCalcer(EnergyArray);
+      
+      //Check if we also need to set the CosineZ binning
+      if (!Oscillator->ReturnCosineZIgnored()) {
+        Oscillator->SetCosineZArrayInCalcer(CosineZArray);
+      }
+    }
+
+    //Setup
+    Oscillator->Setup();
+
+    //Append OscillatorBase* object to the vector
+    Oscillators.push_back(Oscillator);
+  }
+  delete OscFactory;
+  
+  if (Oscillators.size() == 0) {
+    std::cerr << "Expected at least one Oscillator object to compare" << std::endl;
+    throw;
+  }
+
+  std::cout << "Finished setup in executable" << std::endl;
+  std::cout << "========================================================" << std::endl;
+  std::cout << "Starting CompareOscillationProbabilities" << std::endl;
+
+  //Check oscillators are all setup equally
+  for (size_t iOsc=1;iOsc<Oscillators.size();iOsc++) {
+
+    std::vector<int> NeutrinoTypes = Oscillators[iOsc]->ReturnNeutrinoTypes();
+    for (size_t iNT=0;iNT<NeutrinoTypes.size();iNT++) {
+      if (NeutrinoTypes[iNT] != (Oscillators[0]->ReturnNeutrinoTypes())[iNT]) {
+	std::cerr << "Neutrino types are wrong!" << std::endl;
+	throw;
+      }
+    }
+    
+    std::vector<NuOscillator::OscillationChannel> OscChannels = Oscillators[iOsc]->ReturnOscChannels();
+    for (size_t iOscChan=0;iOscChan<OscChannels.size();iOscChan++) {
+      if (OscChannels[iOscChan].GeneratedFlavour != (Oscillators[0]->ReturnOscChannels())[iOscChan].GeneratedFlavour) {
+	std::cerr << "Oscillation channels are wrong!" << std::endl;
+	throw;
+      }
+      if (OscChannels[iOscChan].DetectedFlavour != (Oscillators[0]->ReturnOscChannels())[iOscChan].DetectedFlavour) {
+	std::cerr << "Oscillation channels are wrong!" << std::endl;
+	throw;
+      }
+    }
+
+    std::vector<FLOAT_T> EnergyArray = Oscillators[iOsc]->ReturnEnergyArray();
+    for (size_t iEnergy=0;iEnergy<EnergyArray.size();iEnergy++) {
+      if (EnergyArray[iEnergy] != (Oscillators[0]->ReturnEnergyArray())[iEnergy]) {
+	std::cerr << "Energy are wrong!" << std::endl;
+	throw;
+      }
+    }
+    
+    if (Oscillators[iOsc]->ReturnCosineZIgnored() != Oscillators[0]->ReturnCosineZIgnored()) {
+      std::cerr << "CosineZIgnore wrong!" << std::endl;
+      throw;
+    }
+
+    std::vector<FLOAT_T> CosineZArray = Oscillators[iOsc]->ReturnCosineZArray();
+    for	(size_t iCosineZ=0;iCosineZ<CosineZArray.size();iCosineZ++) {
+      if (CosineZArray[iCosineZ] != (Oscillators[0]->ReturnCosineZArray())[iCosineZ]) {
+        std::cerr << "CosineZ are wrong!" << std::endl;
+        throw;
+      }
+    }
+  }
+
+  //Build the arrays
+  std::vector< std::vector< std::vector< std::vector< std::vector<FLOAT_T> > > > > ProbabilityArray(Oscillators.size());
+  for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
+    ProbabilityArray[iOsc].resize((Oscillators[iOsc]->ReturnNeutrinoTypes()).size());
+      
+    for (size_t iNT=0;iNT<(Oscillators[iOsc]->ReturnNeutrinoTypes()).size();iNT++) {
+      ProbabilityArray[iOsc][iNT].resize((Oscillators[iOsc]->ReturnOscChannels()).size());
+      
+      for (int iChan=0;iChan<(Oscillators[iOsc]->ReturnOscChannels()).size();iChan++) {
+	ProbabilityArray[iOsc][iNT][iChan].resize(Oscillators[iOsc]->ReturnNEnergyPoints());
+	
+	if (Oscillators[iOsc]->ReturnCosineZIgnored()) {
+	  for (int iEnergy=0;iEnergy<Oscillators[iOsc]->ReturnNEnergyPoints();iEnergy++) {
+	    ProbabilityArray[iOsc][iNT][iChan][iEnergy].resize(1);
+	  }
+	} else {
+	  for (int iEnergy=0;iEnergy<Oscillators[iOsc]->ReturnNEnergyPoints();iEnergy++) {
+	    ProbabilityArray[iOsc][iNT][iChan][iEnergy].resize(Oscillators[iOsc]->ReturnNCosineZPoints());
+	  }
+	}
+	
+      }
+    }
+  }
+
+  std::cout << "========================================================" << std::endl;
+  std::cout << "Calculating Probabilities..." << std::endl;
+  
+  for (size_t iOsc=0;iOsc<Oscillators.size();iOsc++) {
+    std::cout << "Creating probability from:" << Oscillators[iOsc]->ReturnImplementationName() << std::endl;
+    
+    if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Basic.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Basic);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Atm.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Atm);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_woYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_woYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe_wDeco.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe_wDeco);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe_wLIV.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe_wLIV);
+    } else if (Oscillators[iOsc]->ReturnNOscParams() == (int)OscParams_Beam_wYe_wNSI.size()) {
+      Oscillators[iOsc]->CalculateProbabilities(OscParams_Beam_wYe_wNSI);
+    } else {
+      std::cerr << "Did not find viable oscillation parameters to hand to the oscillation probability calculater" << std::endl;
+      std::cerr << "Oscillator->ReturnNOscParams():" << Oscillators[iOsc]->ReturnNOscParams() << std::endl;
+      throw std::runtime_error("Invalid setup");
+    }
+
+    for (size_t iNT=0;iNT<(Oscillators[iOsc]->ReturnNeutrinoTypes()).size();iNT++) {
+      int NeutrinoType = (Oscillators[iOsc]->ReturnNeutrinoTypes())[iNT];
+      
+      for (size_t iOscChan=1;iOscChan<(Oscillators[iOsc]->ReturnOscChannels()).size();iOscChan++) {
+	int InitFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].GeneratedFlavour;
+	int FinalFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].GeneratedFlavour;
+	
+	for (size_t iEnergy=0;iEnergy<(Oscillators[0]->ReturnEnergyArray()).size();iEnergy++) {
+	  FLOAT_T Energy = (Oscillators[0]->ReturnEnergyArray())[iEnergy];
+	  
+	  if (Oscillators[iOsc]->ReturnCosineZIgnored()) {
+	    const FLOAT_T Probability = Oscillators[iOsc]->ReturnOscillationProbability(InitFlav,FinalFlav,Energy);
+	    ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][0] = Probability;
+	  } else {
+	    for (size_t iCosineZ=0;iCosineZ<(Oscillators[iOsc]->ReturnCosineZArray()).size();iCosineZ++) {
+	      FLOAT_T CosineZ = (Oscillators[iOsc]->ReturnCosineZArray())[iCosineZ];
+	      const FLOAT_T Probability = Oscillators[iOsc]->ReturnOscillationProbability(InitFlav,FinalFlav,Energy,CosineZ);
+	      ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][iCosineZ] = Probability;
+	    }
+	  }
+	  
+	}
+      }
+    }
+  }
+
+  std::cout << "========================================================" << std::endl;
+  std::cout << "Comparing oscillation probabilities.." << std::endl;
+
+  std::vector<FLOAT_T> LargestDiff(Oscillators.size()-1,0.);
+  
+  if (Oscillators[0]->ReturnCosineZIgnored()) {
+    std::cout << std::setw(10) << "Nu Type" << " : " << std::setw(12) << "Gen Flavour" << "->" << std::setw(12) << "Det Flavour" << " | " << std::setw(15) << "Energy" << " || " << std::setw(25) << Oscillators[0]->ReturnImplementationName();
+    for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
+      std::cout << " | " << std::setw(25) << Oscillators[iOsc]->ReturnImplementationName() << " (" << std::setw(15) << "Differrence" << ")";
+    }
+    std::cout << std::endl;
+  } else {
+    std::cout << std::setw(10) << "Nu Type" << " : " << std::setw(12) << "Gen Flavour" << "->" << std::setw(12) << "Det Flavour" << " | " << std::setw(15) << "Energy" << " | " << std::setw(15) << "Cosine Z" << " || " << std::setw(25) << Oscillators[0]->ReturnImplementationName();
+    for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
+      std::cout << " | " << std::setw(25) << Oscillators[iOsc]->ReturnImplementationName() << " (" << std::setw(15) << "Differrence" << ")";
+    }
+    std::cout << std::endl;
+  }
+  
+  for (size_t iNT=0;iNT<ProbabilityArray[0].size();iNT++) {
+    for (size_t iOscChan=0;iOscChan<ProbabilityArray[0][iNT].size();iOscChan++) {
+      for (size_t iEnergy=0;iEnergy<ProbabilityArray[0][iNT][iOscChan].size();iEnergy++) {
+	
+	if (Oscillators[0]->ReturnCosineZIgnored()) {
+	  std::cout << std::setw(10) << (Oscillators[0]->ReturnNeutrinoTypes())[iNT] << " : " << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].GeneratedFlavour << "->" << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].DetectedFlavour << " | " << std::setw(15) << (Oscillators[0]->ReturnEnergyArray())[iEnergy] << " || " << std::setw(25) << ProbabilityArray[0][iNT][iOscChan][iEnergy][0];
+	  for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
+	    std::cout << " | " << std::setw(25) << ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][0] << " (" << std::setw(15) << ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][0]-ProbabilityArray[0][iNT][iOscChan][iEnergy][0] << ")";
+	  }
+	  std::cout << std::endl;
+	} else {
+	  for (size_t iCosineZ=0;iCosineZ<ProbabilityArray[0][iNT][iOscChan][iEnergy].size();iCosineZ++) {
+	    std::cout << std::setw(10) << (Oscillators[0]->ReturnNeutrinoTypes())[iNT] << " : " << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].GeneratedFlavour << "->" << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].DetectedFlavour << " | " << std::setw(15) << (Oscillators[0]->ReturnEnergyArray())[iEnergy] << " | " << std::setw(15) << (Oscillators[0]->ReturnCosineZArray())[iCosineZ] << " || " << std::setw(25) << ProbabilityArray[0][iNT][iOscChan][iEnergy][iCosineZ];
+	    for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
+	      FLOAT_T Diff = ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][iCosineZ]-ProbabilityArray[0][iNT][iOscChan][iEnergy][iCosineZ];
+	      if (fabs(Diff) > LargestDiff[iOsc-1]) {LargestDiff[iOsc-1] = fabs(Diff);}
+	      
+	      std::cout << " | " << std::setw(25) << ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][iCosineZ] << " (" << std::setw(15) << Diff << ")";
+	    }
+	    std::cout << std::endl;
+	  }
+	}
+	
+      }
+    }
+  }
+
+  std::cout << "Largest differences found: -" << std::endl;
+  for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
+    std::cout << "\t" << Oscillators[iOsc]->ReturnImplementationName() << " to " << Oscillators[0]->ReturnImplementationName() << " = " << LargestDiff[iOsc-1] << std::endl;
+  }
+  
+  std::cout << "Finished executable" << std::endl;
+  std::cout << "========================================================" << std::endl;
+}

--- a/Apps/CompareOscillationProbabilities.cpp
+++ b/Apps/CompareOscillationProbabilities.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
   //============================================================================================================
   std::vector<FLOAT_T> EnergyArray = logspace(0.1,10.,1e3);
   std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1);
-
+  
   std::vector<FLOAT_T> OscParams_Basic = ReturnOscParams_Basic();
   std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
   std::vector<FLOAT_T> OscParams_Beam_woYe = ReturnOscParams_Beam_woYe();
@@ -187,9 +187,9 @@ int main(int argc, char **argv) {
     for (size_t iNT=0;iNT<(Oscillators[iOsc]->ReturnNeutrinoTypes()).size();iNT++) {
       int NeutrinoType = (Oscillators[iOsc]->ReturnNeutrinoTypes())[iNT];
       
-      for (size_t iOscChan=1;iOscChan<(Oscillators[iOsc]->ReturnOscChannels()).size();iOscChan++) {
-	int InitFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].GeneratedFlavour;
-	int FinalFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].GeneratedFlavour;
+      for (size_t iOscChan=0;iOscChan<(Oscillators[iOsc]->ReturnOscChannels()).size();iOscChan++) {
+	int InitFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].GeneratedFlavour * NeutrinoType;
+	int FinalFlav = (Oscillators[iOsc]->ReturnOscChannels())[iOscChan].DetectedFlavour * NeutrinoType;
 	
 	for (size_t iEnergy=0;iEnergy<(Oscillators[0]->ReturnEnergyArray()).size();iEnergy++) {
 	  FLOAT_T Energy = (Oscillators[0]->ReturnEnergyArray())[iEnergy];
@@ -201,6 +201,7 @@ int main(int argc, char **argv) {
 	    for (size_t iCosineZ=0;iCosineZ<(Oscillators[iOsc]->ReturnCosineZArray()).size();iCosineZ++) {
 	      FLOAT_T CosineZ = (Oscillators[iOsc]->ReturnCosineZArray())[iCosineZ];
 	      const FLOAT_T Probability = Oscillators[iOsc]->ReturnOscillationProbability(InitFlav,FinalFlav,Energy,CosineZ);
+
 	      ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][iCosineZ] = Probability;
 	    }
 	  }
@@ -229,18 +230,27 @@ int main(int argc, char **argv) {
     std::cout << std::endl;
   }
   
-  for (size_t iNT=0;iNT<ProbabilityArray[0].size();iNT++) {
-    for (size_t iOscChan=0;iOscChan<ProbabilityArray[0][iNT].size();iOscChan++) {
-      for (size_t iEnergy=0;iEnergy<ProbabilityArray[0][iNT][iOscChan].size();iEnergy++) {
-	
-	if (Oscillators[0]->ReturnCosineZIgnored()) {
+  if (Oscillators[0]->ReturnCosineZIgnored()) {
+
+    for (size_t iEnergy=0;iEnergy<ProbabilityArray[0][0][0].size();iEnergy++) {
+      for (size_t iNT=0;iNT<ProbabilityArray[0].size();iNT++) {
+	for (size_t iOscChan=0;iOscChan<ProbabilityArray[0][0].size();iOscChan++) {
+	  
 	  std::cout << std::setw(10) << (Oscillators[0]->ReturnNeutrinoTypes())[iNT] << " : " << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].GeneratedFlavour << "->" << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].DetectedFlavour << " | " << std::setw(15) << (Oscillators[0]->ReturnEnergyArray())[iEnergy] << " || " << std::setw(25) << ProbabilityArray[0][iNT][iOscChan][iEnergy][0];
 	  for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
 	    std::cout << " | " << std::setw(25) << ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][0] << " (" << std::setw(15) << ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][0]-ProbabilityArray[0][iNT][iOscChan][iEnergy][0] << ")";
 	  }
 	  std::cout << std::endl;
-	} else {
-	  for (size_t iCosineZ=0;iCosineZ<ProbabilityArray[0][iNT][iOscChan][iEnergy].size();iCosineZ++) {
+	}
+      }
+    }
+  } else {
+    
+    for (size_t iEnergy=0;iEnergy<ProbabilityArray[0][0][0].size();iEnergy++) {
+      for (size_t iCosineZ=0;iCosineZ<ProbabilityArray[0][0][0][0].size();iCosineZ++) {
+	for (size_t iNT=0;iNT<ProbabilityArray[0].size();iNT++) {
+	  for (size_t iOscChan=0;iOscChan<ProbabilityArray[0][0].size();iOscChan++) {
+	    
 	    std::cout << std::setw(10) << (Oscillators[0]->ReturnNeutrinoTypes())[iNT] << " : " << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].GeneratedFlavour << "->" << std::setw(12) << (Oscillators[0]->ReturnOscChannels())[iOscChan].DetectedFlavour << " | " << std::setw(15) << (Oscillators[0]->ReturnEnergyArray())[iEnergy] << " | " << std::setw(15) << (Oscillators[0]->ReturnCosineZArray())[iCosineZ] << " || " << std::setw(25) << ProbabilityArray[0][iNT][iOscChan][iEnergy][iCosineZ];
 	    for (size_t iOsc=1;iOsc<ProbabilityArray.size();iOsc++) {
 	      FLOAT_T Diff = ProbabilityArray[iOsc][iNT][iOscChan][iEnergy][iCosineZ]-ProbabilityArray[0][iNT][iOscChan][iEnergy][iCosineZ];

--- a/Apps/DragRace.cpp
+++ b/Apps/DragRace.cpp
@@ -22,8 +22,8 @@ int main(int argc, char **argv) {
   }
   int nThrows = atoi(argv[1]);
   
-  std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
-  std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
+  std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e2);
+  std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e2);
 
   std::vector<FLOAT_T> OscParams_Basic = ReturnOscParams_Basic();
   std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
       Oscillator->SetEnergyArrayInCalcer(EnergyArray);
       
       //Check if we also need to set the CosineZ binning
-      if (!Oscillator->CosineZIgnored()) {
+      if (!Oscillator->ReturnCosineZIgnored()) {
         Oscillator->SetCosineZArrayInCalcer(CosineZArray);
       }
     }
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
     auto t2 = high_resolution_clock::now();
     duration<double, std::milli> ms_double = t2 - t1;
 
-    if (Oscillators[iOsc]->CosineZIgnored()) {
+    if (Oscillators[iOsc]->ReturnCosineZIgnored()) {
       std::cout << Oscillators[iOsc]->ReturnImplementationName() << " ended drag race - took " << ms_double.count()/nThrows << " milliseconds per reweight (Using nEnergyPoints = " << Oscillators[iOsc]->ReturnNEnergyPoints() << ")" << std::endl;
     } else {
       std::cout << Oscillators[iOsc]->ReturnImplementationName() << " ended drag race - took " << ms_double.count()/nThrows << " milliseconds per reweight (Using nEnergyPoints = " << Oscillators[iOsc]->ReturnNEnergyPoints() << ", nCosineZPoints = " << Oscillators[iOsc]->ReturnNCosineZPoints() << ")" << std::endl;

--- a/Apps/DragRace.cpp
+++ b/Apps/DragRace.cpp
@@ -22,8 +22,8 @@ int main(int argc, char **argv) {
   }
   int nThrows = atoi(argv[1]);
   
-  std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e2);
-  std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e2);
+  std::vector<FLOAT_T> EnergyArray = logspace(0.1,100.,1e3);
+  std::vector<FLOAT_T> CosineZArray = linspace(-1.0,1.0,1e3);
 
   std::vector<FLOAT_T> OscParams_Basic = ReturnOscParams_Basic();
   std::vector<FLOAT_T> OscParams_Atm = ReturnOscParams_Atm();

--- a/Apps/OscProbCalcerComparison.cpp
+++ b/Apps/OscProbCalcerComparison.cpp
@@ -63,7 +63,7 @@ int main() {
       Oscillator->SetEnergyArrayInCalcer(EnergyArray);
       
       //Check if we also need to set the CosineZ binning
-      if (!Oscillator->CosineZIgnored()) {
+      if (!Oscillator->ReturnCosineZIgnored()) {
         Oscillator->SetCosineZArrayInCalcer(CosineZArray);
       }
     }

--- a/Apps/SingleOscillator.cpp
+++ b/Apps/SingleOscillator.cpp
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
     Oscillator->SetEnergyArrayInCalcer(EnergyArray);
     
     //Check if we also need to set the CosineZ binning
-    if (!Oscillator->CosineZIgnored()) {
+    if (!Oscillator->ReturnCosineZIgnored()) {
       Oscillator->SetCosineZArrayInCalcer(CosineZArray);
     }
   }
@@ -130,7 +130,7 @@ int main(int argc, char **argv) {
 
 	  if (!Oscillator->HasOscProbCalcerGotOscillationChannel(std::abs(GenFlav),std::abs(DetFlav))) continue;
 	  
-	  if (Oscillator->CosineZIgnored()) {
+	  if (Oscillator->ReturnCosineZIgnored()) {
 	    std::vector<FLOAT_T> EnergyBinning = Oscillator->ReturnBinEdgesForPlotting(true);
 	    
 	    TH1D* Hist = new TH1D(Form("Probability_%i_%i_%i",NuType,GenFlav,DetFlav),Title,EnergyBinning.size()-1,EnergyBinning.data());

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ LIST(APPEND ALL_Engines
   Prob3ppLinear
   ProbGPULinear
   NuFASTLinear
+  NuFASTEarth
   NuSQUIDSLinear
   OscProb
   GLoBESLinear
@@ -98,6 +99,10 @@ endif()
 
 if(NOT DEFINED NuFASTLinear_BRANCH)
   set(NuFASTLinear_BRANCH "v1.1")
+endif()
+
+if(NOT DEFINED NuFASTEarth_BRANCH)
+  set(NuFASTEarth_BRANCH "v1.1.0")
 endif()
 
 if(NOT DEFINED NuSQUIDSLinear_BRANCH)
@@ -324,12 +329,41 @@ endif()
 
 if(${UseNuFASTLinear} EQUAL 1)
   CPMAddPackage(
-    NAME NuFAST
+    NAME NuFAST_LBL
     GIT_TAG ${NuFASTLinear_BRANCH}
     GITHUB_REPOSITORY PeterDenton/NuFast-LBL
     DOWNLOAD_ONLY
   )
   target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseNuFASTLinear=1)
+endif()
+
+if(${UseNuFASTEarth} EQUAL 1)
+  CPMFindPackage(
+    NAME NUFAST_EARTH
+    GIT_TAG ${NuFASTEarth_BRANCH}
+    GITHUB_REPOSITORY PeterDenton/NuFast-Earth
+    DOWNLOAD_ONLY YES
+  )
+
+  file(GLOB NUFAST_EARTH_SOURCES
+    "${NUFAST_EARTH_SOURCE_DIR}/src/*.cpp"
+  )
+
+  add_library(nufast_earth ${NUFAST_EARTH_SOURCES})
+
+  set_target_properties(nufast_earth PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+  
+  target_include_directories(nufast_earth PUBLIC
+    $<BUILD_INTERFACE:${NUFAST_EARTH_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  
+  install(TARGETS nufast_earth
+    EXPORT NuOscillator-targets
+    LIBRARY DESTINATION lib/
+  )
 endif()
 
 if(${UseOscProb} EQUAL 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,15 +345,9 @@ if(${UseNuFASTEarth} EQUAL 1)
     DOWNLOAD_ONLY YES
   )
 
-  file(GLOB NUFAST_EARTH_SOURCES
-    "${NUFAST_EARTH_SOURCE_DIR}/src/*.cpp"
-  )
-
+  file(GLOB NUFAST_EARTH_SOURCES "${NUFAST_EARTH_SOURCE_DIR}/src/*.cpp")
   add_library(nufast_earth ${NUFAST_EARTH_SOURCES})
-
-  set_target_properties(nufast_earth PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
-  )
+  set_target_properties(nufast_earth PROPERTIES POSITION_INDEPENDENT_CODE ON)
   
   target_include_directories(nufast_earth PUBLIC
     $<BUILD_INTERFACE:${NUFAST_EARTH_SOURCE_DIR}/include>
@@ -364,6 +358,8 @@ if(${UseNuFASTEarth} EQUAL 1)
     EXPORT NuOscillator-targets
     LIBRARY DESTINATION lib/
   )
+
+  target_compile_definitions(NuOscillatorCompilerOptions INTERFACE UseNuFASTEarth=1)
 endif()
 
 if(${UseOscProb} EQUAL 1)

--- a/Constants/OscillatorConstants.h
+++ b/Constants/OscillatorConstants.h
@@ -160,6 +160,10 @@ inline std::vector<std::string> ReturnKnownConfigs() {
   ConfigNames.push_back("./NuOscillatorConfigs/Binned_NuFASTLinear.yaml");
 #endif
 
+#if UseNuFASTEarth == 1
+  ConfigNames.push_back("./NuOscillatorConfigs/Binned_NuFASTEarth.yaml");
+#endif
+
 #if UseNuSQUIDSLinear == 1
   ConfigNames.push_back("./NuOscillatorConfigs/Binned_NuSQUIDSLinear.yaml");
 #endif

--- a/NuOscillatorConfigs/Binned_CUDAProb3.yaml
+++ b/NuOscillatorConfigs/Binned_CUDAProb3.yaml
@@ -12,7 +12,8 @@ OscProbCalcerSetup:
   ImplementationName: "CUDAProb3"
   EarthModelFileName: "./build/_deps/cudaprob3-src/models/PREM_4layer.dat"
   UseEarthModelSystematics: false
-  Layers: 4  
+  Layers: 4
+  
   UseProductionHeightsAveraging: false
   ProductionHeightsFileName: "./inputs/ProdHeightDist_E561_cZ520_N1_hbin2.5.root"
   ProductionHeightsHistFlavourSuffixes:
@@ -22,6 +23,7 @@ OscProbCalcerSetup:
     Nuebar: "nuebar"
     Numubar: "numubar"
     Nutaubar: "numubar"
+    
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/NuOscillatorConfigs/Binned_NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/Binned_NuFASTEarth.yaml
@@ -10,6 +10,10 @@ Binned:
 
 OscProbCalcerSetup:
   ImplementationName: "NuFASTEarth"
+  DetectorDepth: 0.
+  EigenValuePrecision: 1
+  EarthModel: "Prob3"
+  #NUniformLayers: 10
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/NuOscillatorConfigs/Binned_NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/Binned_NuFASTEarth.yaml
@@ -1,0 +1,22 @@
+General:
+  Verbosity: "NONE"
+  CosineZIgnored: false
+  CalculationType: "Binned"
+
+Binned:
+  FileName: "./Inputs/ExampleAtmosphericBinning.root"
+  EnergyAxisHistName: "EnergyAxisBinning"
+  CosineZAxisHistName: "CosineZAxisBinning"
+
+OscProbCalcerSetup:
+  ImplementationName: "NuFASTEarth"
+  OscChannelMapping:
+    - Entry: "Electron:Electron"
+    - Entry: "Electron:Muon"
+    - Entry: "Electron:Tau"
+    - Entry: "Muon:Electron"
+    - Entry: "Muon:Muon"
+    - Entry: "Muon:Tau"
+    - Entry: "Tau:Electron"
+    - Entry: "Tau:Muon"
+    - Entry: "Tau:Tau"

--- a/NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
@@ -3,6 +3,10 @@ General:
 
 OscProbCalcerSetup:
   ImplementationName: "NuFASTEarth"
+  DetectorDepth: 0.
+  EigenValuePrecision: 1
+  EarthModel: "Prob3"
+  #NUniformLayers: 10
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/OscProbCalcerConfigs/NuFASTEarth.yaml
@@ -1,0 +1,15 @@
+General:
+  Verbosity: "NONE"
+
+OscProbCalcerSetup:
+  ImplementationName: "NuFASTEarth"
+  OscChannelMapping:
+    - Entry: "Electron:Electron"
+    - Entry: "Electron:Muon"
+    - Entry: "Electron:Tau"
+    - Entry: "Muon:Electron"
+    - Entry: "Muon:Muon"
+    - Entry: "Muon:Tau"
+    - Entry: "Tau:Electron"
+    - Entry: "Tau:Muon"
+    - Entry: "Tau:Tau"

--- a/NuOscillatorConfigs/Unbinned_NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/Unbinned_NuFASTEarth.yaml
@@ -5,6 +5,10 @@ General:
 
 OscProbCalcerSetup:
   ImplementationName: "NuFASTEarth"
+  DetectorDepth: 0.
+  EigenValuePrecision: 1
+  EarthModel: "Prob3"
+  #NUniformLayers: 10
   OscChannelMapping:
     - Entry: "Electron:Electron"
     - Entry: "Electron:Muon"

--- a/NuOscillatorConfigs/Unbinned_NuFASTEarth.yaml
+++ b/NuOscillatorConfigs/Unbinned_NuFASTEarth.yaml
@@ -1,0 +1,17 @@
+General:
+  Verbosity: "NONE"
+  CosineZIgnored: false
+  CalculationType: "Unbinned"
+
+OscProbCalcerSetup:
+  ImplementationName: "NuFASTEarth"
+  OscChannelMapping:
+    - Entry: "Electron:Electron"
+    - Entry: "Electron:Muon"
+    - Entry: "Electron:Tau"
+    - Entry: "Muon:Electron"
+    - Entry: "Muon:Muon"
+    - Entry: "Muon:Tau"
+    - Entry: "Tau:Electron"
+    - Entry: "Tau:Muon"
+    - Entry: "Tau:Tau"

--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -59,7 +59,6 @@ if(${UseNuFASTLinear} EQUAL 1)
 endif()
 
 if(${UseNuFASTEarth} EQUAL 1)
-  target_include_directories(OscProbCalcer PRIVATE ${NUFAST_EARTH_INC_DIR})
   target_sources(OscProbCalcer PRIVATE OscProbCalcer_NuFASTEarth.cpp)
   target_link_libraries(OscProbCalcer nufast_earth)
   list(APPEND HEADERS OscProbCalcer_NuFASTEarth.h)

--- a/OscProbCalcer/CMakeLists.txt
+++ b/OscProbCalcer/CMakeLists.txt
@@ -53,9 +53,16 @@ if(${UseProb3ppLinear} EQUAL 1)
 endif()
 
 if(${UseNuFASTLinear} EQUAL 1)
-  include_directories(${NuFAST_SOURCE_DIR})
+  include_directories(${NuFAST_LBL_SOURCE_DIR})
   target_sources(OscProbCalcer PRIVATE OscProbCalcer_NuFASTLinear.cpp)
   list(APPEND HEADERS OscProbCalcer_NuFASTLinear.h)
+endif()
+
+if(${UseNuFASTEarth} EQUAL 1)
+  target_include_directories(OscProbCalcer PRIVATE ${NUFAST_EARTH_INC_DIR})
+  target_sources(OscProbCalcer PRIVATE OscProbCalcer_NuFASTEarth.cpp)
+  target_link_libraries(OscProbCalcer nufast_earth)
+  list(APPEND HEADERS OscProbCalcer_NuFASTEarth.h)
 endif()
 
 if(${UseNuSQUIDSLinear} EQUAL 1)

--- a/OscProbCalcer/OscProbCalcerFactory.cpp
+++ b/OscProbCalcer/OscProbCalcerFactory.cpp
@@ -20,6 +20,10 @@
 #include "OscProbCalcer/OscProbCalcer_NuFASTLinear.h"
 #endif
 
+#if UseNuFASTEarth==1
+#include "OscProbCalcer/OscProbCalcer_NuFASTEarth.h"
+#endif
+
 #if UseNuSQUIDSLinear==1
 #include "OscProbCalcer/OscProbCalcer_NuSQUIDSLinear.h"
 #endif
@@ -104,6 +108,17 @@ OscProbCalcerBase* OscProbCalcerFactory::CreateOscProbCalcer(YAML::Node OscProbC
 #if UseNuFASTLinear==1
     OscProbCalcerNuFASTLinear* NuFASTLinear = new OscProbCalcerNuFASTLinear(OscProbCalcerConfig);
     Calcer = (OscProbCalcerBase*)NuFASTLinear;
+    if (Verbose >= NuOscillator::INFO) {std::cout << "Initalised OscProbCalcer Implementation:" << Calcer->ReturnImplementationName() << " in OscProbCalcerFactory object" << std::endl;}
+#else
+    std::cerr << "OscProbCalcerFactory was requsted to create " << OscProbCalcerImplementationToCreate << " OscProbCalcer but Use" << OscProbCalcerImplementationToCreate << " is undefined. Indicates problem in setup" << std::endl;
+    throw std::runtime_error("Invalid setup");
+#endif
+  }
+
+  else if (OscProbCalcerImplementationToCreate == "NuFASTEarth") {
+#if UseNuFASTEarth==1
+    OscProbCalcerNuFASTEarth* NuFASTEarth = new OscProbCalcerNuFASTEarth(OscProbCalcerConfig);
+    Calcer = (OscProbCalcerBase*)NuFASTEarth;
     if (Verbose >= NuOscillator::INFO) {std::cout << "Initalised OscProbCalcer Implementation:" << Calcer->ReturnImplementationName() << " in OscProbCalcerFactory object" << std::endl;}
 #else
     std::cerr << "OscProbCalcerFactory was requsted to create " << OscProbCalcerImplementationToCreate << " OscProbCalcer but Use" << OscProbCalcerImplementationToCreate << " is undefined. Indicates problem in setup" << std::endl;

--- a/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
@@ -1,0 +1,81 @@
+#include "OscProbCalcer_NuFASTEarth.h"
+
+#include "NuFastEarth.h"
+#include "Matrix.h"
+
+OscProbCalcerNuFASTEarth::OscProbCalcerNuFASTEarth(YAML::Node Config_) : OscProbCalcerBase(Config_)
+{
+  //=======
+  //Grab information from the config
+
+  DetectorDepth = 2.0; // detector depth in km
+  
+  //=======
+  fNOscParams = kNOscParams;
+
+  fNNeutrinoTypes = 2;
+  InitialiseNeutrinoTypesArray(fNNeutrinoTypes);
+  fNeutrinoTypes[0] = Nu;
+  fNeutrinoTypes[1] = Nubar;
+  
+  // This implementation only considers atmopsheric propagation, thus no requirement to set cosineZ array
+  IgnoreCosineZBinning(false);
+}
+
+OscProbCalcerNuFASTEarth::~OscProbCalcerNuFASTEarth() {
+  if (EarthDensity) {delete EarthDensity;}
+}
+
+void OscProbCalcerNuFASTEarth::SetupPropagator() {
+  //=============================
+  PREM_Four* PREMFour = new PREM_Four();
+  EarthDensity = dynamic_cast<Earth_Density*>(PREMFour);
+  //=============================
+
+  ProbEngine.Set_Earth(DetectorDepth, EarthDensity);
+}
+
+void OscProbCalcerNuFASTEarth::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
+ 
+  const double s12sq = OscParams[kTH12];
+  const double s13sq = OscParams[kTH13];
+  const double s23sq = OscParams[kTH23];
+  const double delta = OscParams[kDCP];
+  const double Dmsq21 = OscParams[kDM12];
+
+  //Need to convert OscParams[kDM23] to kDM31
+  const double Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
+
+  for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
+
+    bool NeutrinoType = (fNeutrinoTypes[iNuType] == Nu) ? true : false;
+    ProbEngine.Set_Oscillation_Parameters(s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31, NeutrinoType);
+    ProbEngine.Set_Spectra(fEnergyArray, fCosineZArray);
+    std::vector<std::vector<Matrix3r>> probabilities = ProbEngine.Get_Probabilities();
+    
+    for (int iCosineZPoint=0;iCosineZPoint<fNCosineZPoints;iCosineZPoint++) {
+      for (int iEnergyPoint=0;iEnergyPoint<fNEnergyPoints;iEnergyPoint++) {
+	for (int iOscChannel = 0; iOscChannel < fNOscillationChannels; iOscChannel++) {
+
+	  int Index = ReturnWeightArrayIndex(iNuType,iOscChannel,iEnergyPoint,iCosineZPoint);
+          const int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour-1;
+          const int dflv = fOscillationChannels[iOscChannel].DetectedFlavour-1;
+	  
+	  fWeightArray[Index] = probabilities[iEnergyPoint][iCosineZPoint].arr[gflv][dflv];
+	}
+      } 
+    }
+    
+  }
+
+}
+
+int OscProbCalcerNuFASTEarth::ReturnWeightArrayIndex(int NuTypeIndex, int OscChanIndex, int EnergyIndex, int CosineZIndex) {
+  int IndexToReturn = NuTypeIndex*fNOscillationChannels*fNCosineZPoints*fNEnergyPoints + OscChanIndex*fNCosineZPoints*fNEnergyPoints + EnergyIndex*fNCosineZPoints + CosineZIndex;
+  return IndexToReturn;
+}
+
+long OscProbCalcerNuFASTEarth::DefineWeightArraySize() {
+  long nCalculationPoints = static_cast<long>(fNEnergyPoints) * fNCosineZPoints * fNOscillationChannels * fNNeutrinoTypes;
+  return nCalculationPoints;
+}

--- a/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
@@ -42,17 +42,13 @@ void OscProbCalcerNuFASTEarth::SetupPropagator() {
   //=============================
   //Set the Earth Model
   if (EarthModel == "Prob3") {
-    PREM_Prob3* PREMProb3 = new PREM_Prob3();
-    EarthDensity = dynamic_cast<Earth_Density*>(PREMProb3);
+    EarthDensity = new PREM_Prob3();
   } else if (EarthModel == "PREM4") {
-    PREM_Four* PREMFour = new PREM_Four();
-    EarthDensity = dynamic_cast<Earth_Density*>(PREMFour);
+    EarthDensity = new PREM_Four();
   } else if (EarthModel == "Full") {
-    PREM_Full* PREMFull = new PREM_Full();
-    EarthDensity = dynamic_cast<Earth_Density*>(PREMFull);
+    EarthDensity = new PREM_Full();
   } else if (EarthModel == "NUniformLayers") {
-    PREM_NUniformLayer* PREMNUniformLayer = new PREM_NUniformLayer(NUniformLayers);
-    EarthDensity = dynamic_cast<Earth_Density*>(PREMNUniformLayer);    
+    EarthDensity = new PREM_NUniformLayer(NUniformLayers);
   }
   //=============================
 
@@ -88,7 +84,7 @@ void OscProbCalcerNuFASTEarth::CalculateProbabilities(const std::vector<FLOAT_T>
 	  int Index = ReturnWeightArrayIndex(iNuType,iOscChannel,iEnergyPoint,iCosineZPoint);
           const int gflv = fOscillationChannels[iOscChannel].GeneratedFlavour-1;
           const int dflv = fOscillationChannels[iOscChannel].DetectedFlavour-1;
-	  
+
 	  fWeightArray[Index] = probabilities[iEnergyPoint][iCosineZPoint].arr[gflv][dflv];
 	}
       } 

--- a/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTEarth.cpp
@@ -8,9 +8,21 @@ OscProbCalcerNuFASTEarth::OscProbCalcerNuFASTEarth(YAML::Node Config_) : OscProb
   //=======
   //Grab information from the config
 
-  DetectorDepth = 2.0; // detector depth in km
+  // detector depth in km
+  DetectorDepth = Config_["OscProbCalcerSetup"]["DetectorDepth"].as<FLOAT_T>();
+
+  //Number of Newton-Raphson iteration, set to negative for exact eigenvalues
+  EigenValuePrecision = Config_["OscProbCalcerSetup"]["EigenValuePrecision"].as<int>(); 
   
+  //Earth model type picked from "Prob3", "PREM4", "Full", "NUniformLayers" (see https://github.com/PeterDenton/NuFast-Earth/blob/main/src/Earth.cpp)
+  EarthModel = Config_["OscProbCalcerSetup"]["EarthModel"].as<std::string>();
+
+  if (EarthModel == "NUniformLayers") {
+    //Number of layers of Earth used in the NuFAST-Earth::PREM_NUniformLayer object - Not used unless EarthModel=="NUniformLayers"
+    NUniformLayers = Config_["OscProbCalcerSetup"]["NUniformLayers"].as<int>();
+  }
   //=======
+  
   fNOscParams = kNOscParams;
 
   fNNeutrinoTypes = 2;
@@ -28,11 +40,24 @@ OscProbCalcerNuFASTEarth::~OscProbCalcerNuFASTEarth() {
 
 void OscProbCalcerNuFASTEarth::SetupPropagator() {
   //=============================
-  PREM_Four* PREMFour = new PREM_Four();
-  EarthDensity = dynamic_cast<Earth_Density*>(PREMFour);
+  //Set the Earth Model
+  if (EarthModel == "Prob3") {
+    PREM_Prob3* PREMProb3 = new PREM_Prob3();
+    EarthDensity = dynamic_cast<Earth_Density*>(PREMProb3);
+  } else if (EarthModel == "PREM4") {
+    PREM_Four* PREMFour = new PREM_Four();
+    EarthDensity = dynamic_cast<Earth_Density*>(PREMFour);
+  } else if (EarthModel == "Full") {
+    PREM_Full* PREMFull = new PREM_Full();
+    EarthDensity = dynamic_cast<Earth_Density*>(PREMFull);
+  } else if (EarthModel == "NUniformLayers") {
+    PREM_NUniformLayer* PREMNUniformLayer = new PREM_NUniformLayer(NUniformLayers);
+    EarthDensity = dynamic_cast<Earth_Density*>(PREMNUniformLayer);    
+  }
   //=============================
 
   ProbEngine.Set_Earth(DetectorDepth, EarthDensity);
+  ProbEngine.Set_Eigenvalue_Precision(EigenValuePrecision);
 }
 
 void OscProbCalcerNuFASTEarth::CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) {
@@ -46,10 +71,13 @@ void OscProbCalcerNuFASTEarth::CalculateProbabilities(const std::vector<FLOAT_T>
   //Need to convert OscParams[kDM23] to kDM31
   const double Dmsq31 = OscParams[kDM23]+OscParams[kDM12]; // eV^2
 
+  const double ProductionHeight = OscParams[kPROD]; //km
+
   for (int iNuType=0;iNuType<fNNeutrinoTypes;iNuType++) {
 
     bool NeutrinoType = (fNeutrinoTypes[iNuType] == Nu) ? true : false;
     ProbEngine.Set_Oscillation_Parameters(s12sq, s13sq, s23sq, delta, Dmsq21, Dmsq31, NeutrinoType);
+    ProbEngine.Set_Production_Height(ProductionHeight);
     ProbEngine.Set_Spectra(fEnergyArray, fCosineZArray);
     std::vector<std::vector<Matrix3r>> probabilities = ProbEngine.Get_Probabilities();
     

--- a/OscProbCalcer/OscProbCalcer_NuFASTEarth.h
+++ b/OscProbCalcer/OscProbCalcer_NuFASTEarth.h
@@ -82,7 +82,7 @@ class OscProbCalcerNuFASTEarth : public OscProbCalcerBase {
   /**
    * @brief Definition of oscillation parameters which are expected in this ProbGPU implementation
    */
-  enum OscParams{kTH12, kTH23, kTH13, kDM12, kDM23, kDCP, kNOscParams};
+  enum OscParams{kTH12, kTH23, kTH13, kDM12, kDM23, kDCP, kPROD, kNOscParams};
   
   /**
    * @brief Define the neutrino and antineutrino values expected by this implementation
@@ -91,7 +91,11 @@ class OscProbCalcerNuFASTEarth : public OscProbCalcerBase {
 
   Earth_Density* EarthDensity;
   Probability_Engine ProbEngine;
+
   FLOAT_T DetectorDepth;
+  int EigenValuePrecision;
+  std::string EarthModel;
+  int NUniformLayers;
 };
 
 #endif

--- a/OscProbCalcer/OscProbCalcer_NuFASTEarth.h
+++ b/OscProbCalcer/OscProbCalcer_NuFASTEarth.h
@@ -1,0 +1,97 @@
+#ifndef __OSCILLATOR_NUFASTEARTH_H__
+#define __OSCILLATOR_NUFASTEARTH_H__
+
+#include "OscProbCalcerBase.h"
+
+#include "NuFastEarth.h"
+
+/**
+ * @file OscProbCalcer_NuFASTEarth.h
+ *
+ * @class OscProbCalcerNuFASTEarth
+ *
+ * @brief Oscillation calculation engine for linear propagation in NuFAST.
+ */
+class OscProbCalcerNuFASTEarth : public OscProbCalcerBase {
+ public:
+
+  /**
+   * @brief Default constructor
+   *
+   * @param Config_ YAML::Node to setup the OscProbCalcerNuFASTEarth() instance
+   */
+  OscProbCalcerNuFASTEarth(YAML::Node Config_);
+
+  /**
+   * @brief Constructor which takes a file path, creates a YAML::Node and calls the default constructor
+   *
+   * @param ConfigName_ File path to config
+   */
+  OscProbCalcerNuFASTEarth(std::string ConfigName_) : OscProbCalcerNuFASTEarth(YAML::LoadFile(ConfigName_)) {}
+  
+  /**
+   * @brief Destructor
+   */
+  virtual ~OscProbCalcerNuFASTEarth();
+
+  // ========================================================================================================================================================================
+  // Functions which need implementation specific code
+
+  /**
+   * @brief Setup NuFAST specific variables
+   */  
+  void SetupPropagator() override;
+  
+  /**
+   * @brief Calculate some oscillation probabilities for a particular oscillation parameter set
+   *
+   * Calculator oscillation probabilities in NuFAST. This function both calculates and stores
+   * the oscillation probabilities in #fWeightArray.
+   *
+   * @param OscParams The parameter set to calculate oscillation probabilities at
+   */
+  void CalculateProbabilities(const std::vector<FLOAT_T>& OscParams) override;
+
+  /**
+   * @brief Return implementation specific index in the weight array for a specific combination of neutrino oscillation channel, energy and cosine zenith
+   * 
+   * @param NuTypeIndex The index in #fNeutrinoTypes (neutrino/antinuetrino) to return the pointer for 
+   * @param OscChanIndex The index in #fOscillationChannels to return the pointer for 
+   * @param EnergyIndex The index in #fEnergyArray to return the pointer for 
+   * @param CosineZIndex The index in #fCosineZArray to return the pointer for 
+   *
+   * @return Index in #fWeightArray which corresponds to the given inputs
+   */
+  int ReturnWeightArrayIndex(int NuTypeIndex, int OscNuIndex, int EnergyIndex, int CosineZIndex=-1) override;
+  
+  /**
+   * @brief Define the size of fWeightArray
+   *
+   * This is implementation specific because because NuFAST is setup to calculate all oscillation channels together, whilst others calculate only a single oscillation channel.
+   *
+   * @return Length that #fWeightArray should be initialised to
+   */
+  long DefineWeightArraySize() override;
+
+  // ========================================================================================================================================================================
+  // Functions which help setup implementation specific code
+
+  // ========================================================================================================================================================================
+  // Variables which are needed for implementation specific code
+
+  /**
+   * @brief Definition of oscillation parameters which are expected in this ProbGPU implementation
+   */
+  enum OscParams{kTH12, kTH23, kTH13, kDM12, kDM23, kDCP, kNOscParams};
+  
+  /**
+   * @brief Define the neutrino and antineutrino values expected by this implementation
+   */
+  enum NuType{Nu=1,Nubar=-1};
+
+  Earth_Density* EarthDensity;
+  Probability_Engine ProbEngine;
+  FLOAT_T DetectorDepth;
+};
+
+#endif

--- a/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
+++ b/OscProbCalcer/OscProbCalcer_NuFASTLinear.cpp
@@ -31,11 +31,13 @@ OscProbCalcerNuFASTLinear::OscProbCalcerNuFASTLinear(YAML::Node Config_) : OscPr
   InitialiseNeutrinoTypesArray(fNNeutrinoTypes);
   fNeutrinoTypes[0] = Nu;
   fNeutrinoTypes[1] = Nubar;
+  
   #if UseMultithreading == 1
   fImplementationName += "-CPU-"+std::to_string(omp_get_max_threads());
   #else
   fImplementationName += "-CPU-"+std::to_string(1);
   #endif
+  
   // This implementation only considers linear propagation, thus no requirement to set cosineZ array
   IgnoreCosineZBinning(true);
 }

--- a/Oscillator/OscillatorBase.cpp
+++ b/Oscillator/OscillatorBase.cpp
@@ -91,8 +91,24 @@ int OscillatorBase::ReturnNEnergyPoints() {
   return fOscProbCalcer->ReturnNEnergyPoints();
 }
 
+std::vector<FLOAT_T> OscillatorBase::ReturnEnergyArray() {
+  return fOscProbCalcer->ReturnEnergyArray();
+}
+
 int OscillatorBase::ReturnNCosineZPoints() {
   return fOscProbCalcer->ReturnNCosineZPoints();
+}
+
+std::vector<FLOAT_T> OscillatorBase::ReturnCosineZArray() {
+  return fOscProbCalcer->ReturnCosineZArray();
+}
+
+std::vector<NuOscillator::OscillationChannel> OscillatorBase::ReturnOscChannels() {
+  return fOscProbCalcer->ReturnOscChannels();
+}
+
+std::vector<int> OscillatorBase::ReturnNeutrinoTypes() {
+  return fOscProbCalcer->ReturnNeutrinoTypes();
 }
 
 const FLOAT_T* OscillatorBase::ReturnPointerToWeightinCalcer(int InitNuFlav, int FinalNuFlav, FLOAT_T EnergyVal, FLOAT_T CosineZVal) {

--- a/Oscillator/OscillatorBase.h
+++ b/Oscillator/OscillatorBase.h
@@ -86,12 +86,36 @@ class OscillatorBase {
   int ReturnNEnergyPoints();
 
   /**
+   * @brief Return the vector of Energy points which are being used by the specific instance of OscProbCalcerBase::OscProbCalcerBase() contained in this instance of OscillatorBase::OscillatorBase()
+   * @return Return the vector of Energy points which are being used by the specific instance of OscProbCalcerBase::OscProbCalcerBase() contained in this instance of OscillatorBase::OscillatorBase()
+   */
+  std::vector<FLOAT_T> ReturnEnergyArray();
+
+  /**
    * @brief Return the number of CosineZ points which are being evaluated in the OscProbCalcerBase::OscProbCalcerBase() object
    *
    * @return Returns an integer describing the number of CosineZ points which are being evaluated in the OscProbCalcerBase::OscProbCalcerBase() object
    */
   int ReturnNCosineZPoints();
 
+  /**
+   * @brief Return the vector of CosineZ points which are being used by the specific instance of OscProbCalcerBase::OscProbCalcerBase() contained in this instance of OscillatorBase::OscillatorBase()
+   * @return Return the vector of CosineZ points which are being used by the specific instance of OscProbCalcerBase::OscProbCalcerBase() contained in this instance of OscillatorBase::OscillatorBase()
+   */
+  std::vector<FLOAT_T> ReturnCosineZArray();
+
+  /**
+   * @brief Return the oscillation channels the specific implementation expects
+   * @return Return the oscillation channels the specific implementation expects
+   */
+  std::vector<NuOscillator::OscillationChannel> ReturnOscChannels();
+
+  /**
+   * @brief Return the neutrino types the specific implementation expects
+   * @return Return the neutrino types the specific implementation expects
+   */
+  std::vector<int> ReturnNeutrinoTypes();
+  
   /**
    * @brief Check whether a particular OscProbCalcerBase::OscProbCalcerBase() instance has a particular oscillation channel
    *
@@ -135,7 +159,7 @@ class OscillatorBase {
    *
    * @return Boolean flag
    */
-  bool CosineZIgnored() {return fCosineZIgnored;}
+  bool ReturnCosineZIgnored() {return fCosineZIgnored;}
 
   /**
    * @brief Return oscillation probability for a given initial and final flavour, for a given energy and cosineZ


### PR DESCRIPTION
# Pull request description:
Implementation of NuFAST-EARTH

Validation -- 

Printout from NuOscillator:
```
  Nu Type :  Gen Flavour-> Det Flavour |          Energy |        Cosine Z ||  Unbinned_CUDAProb3-CPU-1 |      Unbinned_NuFASTEarth (    Differrence)
         1 :            1->           1 |        0.107408 |       -0.933333 ||                  0.195955 |                  0.195598 (   -0.000357259)
         1 :            1->           2 |        0.107408 |       -0.933333 ||                  0.467674 |                  0.472804 (     0.00512932)
         1 :            1->           3 |        0.107408 |       -0.933333 ||                  0.336371 |                  0.331599 (    -0.00477206)
         1 :            2->           1 |        0.107408 |       -0.933333 ||                  0.288222 |                  0.283521 (    -0.00470094)
         1 :            2->           2 |        0.107408 |       -0.933333 ||                  0.103614 |                  0.101842 (    -0.00177205)
         1 :            2->           3 |        0.107408 |       -0.933333 ||                  0.608164 |                  0.614637 (     0.00647299)
         1 :            3->           1 |        0.107408 |       -0.933333 ||                  0.515823 |                  0.520881 (      0.0050582)
         1 :            3->           2 |        0.107408 |       -0.933333 ||                  0.428712 |                  0.425355 (    -0.00335726)
         1 :            3->           3 |        0.107408 |       -0.933333 ||                 0.0554655 |                 0.0537645 (    -0.00170093)
        -1 :            1->           1 |        0.107408 |       -0.933333 ||                  0.721465 |                  0.719123 (      -0.002342)
        -1 :            1->           2 |        0.107408 |       -0.933333 ||                   0.18757 |                  0.191362 (     0.00379235)
        -1 :            1->           3 |        0.107408 |       -0.933333 ||                 0.0909654 |                  0.089515 (    -0.00145034)
        -1 :            2->           1 |        0.107408 |       -0.933333 ||                 0.0823358 |                 0.0809042 (    -0.00143165)
        -1 :            2->           2 |        0.107408 |       -0.933333 ||                  0.489761 |                  0.473642 (     -0.0161187)
        -1 :            2->           3 |        0.107408 |       -0.933333 ||                  0.427903 |                  0.445454 (      0.0175504)
        -1 :            3->           1 |        0.107408 |       -0.933333 ||                    0.1962 |                  0.199973 (     0.00377365)
        -1 :            3->           2 |        0.107408 |       -0.933333 ||                  0.322669 |                  0.334995 (      0.0123264)
        -1 :            3->           3 |        0.107408 |       -0.933333 ||                  0.481131 |                  0.465031 (        -0.0161)
```

Printout from NuFAST-EARTH:
```
m[barrowd@pplxint13 NuFAST-Earth]$ ./main 
Neutrinos
   E [GeV]    |     cosz     |       Pee      |       Pem      |       Pet      |       Pme      |     Pmm        |      Pmt       |       Pte      |     Ptm        |      Ptt      |
0.107408      |  -0.933333   |     0.195598   |     0.472804   |     0.331599   |     0.283521   |     0.101842   |     0.614637   |     0.520881   |     0.425355   |    0.0537645
Anti-neutrinos
   E [GeV]    |     cosz     |       Pee      |       Pem      |       Pet      |       Pme      |     Pmm        |      Pmt       |       Pte      |     Ptm        |      Ptt      |
0.107408      |  -0.933333   |     0.719123   |     0.191362   |     0.089515   |    0.0809042   |     0.473642   |     0.445454   |     0.199973   |     0.334995   |     0.465031
```

## Changes or fixes:


## Examples:
