### PR TITLE
Open Quantum System in NuOscillator

### DIFF
--- a/OscProbCalcer/OscProbCalcer_OscProb.cpp
+++ b/OscProbCalcer/OscProbCalcer_OscProb.cpp
@@ -9,6 +9,7 @@
 #include "inc/PMNS_NUNM.h"
 #include "inc/PMNS_SNSI.h"
 #include "inc/PMNS_LIV.h"
+#include "inc/PMNS_OQS.h"
 
 OscProbCalcerOscProb::OscProbCalcerOscProb(YAML::Node Config_) : OscProbCalcerBase(Config_), fPMNSObj(nullptr) {
   //=======
@@ -109,6 +110,7 @@ OscProb::PMNS_Base* OscProbCalcerOscProb::GetPMNSObj() {
  if(fOscType==kIter)         return new OscProb::PMNS_Iter();
  if(fOscType==kNUNM)         return new OscProb::PMNS_NUNM();
  if(fOscType==kLIV)          return new OscProb::PMNS_LIV();
+ if(fOscType==kOQS)          return new OscProb::PMNS_OQS();
 
  return new OscProb::PMNS_Fast();
 }
@@ -306,6 +308,55 @@ void OscProbCalcerOscProb::SetPMNSParams() {
     LIV->SetcT(2, 2, 8, GetOscillationParameter(kcT_tautau_8), 0.);
   }
 
+  // Set OQS parameters
+  if(OscProb::PMNS_OQS* OQS = dynamic_cast<OscProb::PMNS_OQS*>(fPMNSObj)) {
+    // Decoherence magnitudes (a_i), i = 1..8
+    OQS->SetDecoElement(1, GetOscillationParameter(kA1));
+    OQS->SetDecoElement(2, GetOscillationParameter(kA2));
+    OQS->SetDecoElement(3, GetOscillationParameter(kA3));
+    OQS->SetDecoElement(4, GetOscillationParameter(kA4));
+    OQS->SetDecoElement(5, GetOscillationParameter(kA5));
+    OQS->SetDecoElement(6, GetOscillationParameter(kA6));
+    OQS->SetDecoElement(7, GetOscillationParameter(kA7));
+    OQS->SetDecoElement(8, GetOscillationParameter(kA8));
+    // Angles theta_ij (i < j)
+    // i = 1
+    OQS->SetDecoAngle(1,2, std::acos(GetOscillationParameter(kTheta12)));
+    OQS->SetDecoAngle(1,3, std::acos(GetOscillationParameter(kTheta13)));
+    OQS->SetDecoAngle(1,4, std::acos(GetOscillationParameter(kTheta14)));
+    OQS->SetDecoAngle(1,5, std::acos(GetOscillationParameter(kTheta15)));
+    OQS->SetDecoAngle(1,6, std::acos(GetOscillationParameter(kTheta16)));
+    OQS->SetDecoAngle(1,7, std::acos(GetOscillationParameter(kTheta17)));
+    OQS->SetDecoAngle(1,8, std::acos(GetOscillationParameter(kTheta18)));
+    // i = 2
+    OQS->SetDecoAngle(2,3, std::acos(GetOscillationParameter(kTheta23)));
+    OQS->SetDecoAngle(2,4, std::acos(GetOscillationParameter(kTheta24)));
+    OQS->SetDecoAngle(2,5, std::acos(GetOscillationParameter(kTheta25)));
+    OQS->SetDecoAngle(2,6, std::acos(GetOscillationParameter(kTheta26)));
+    OQS->SetDecoAngle(2,7, std::acos(GetOscillationParameter(kTheta27)));
+    OQS->SetDecoAngle(2,8, std::acos(GetOscillationParameter(kTheta28)));
+    // i = 3
+    OQS->SetDecoAngle(3,4, std::acos(GetOscillationParameter(kTheta34)));
+    OQS->SetDecoAngle(3,5, std::acos(GetOscillationParameter(kTheta35)));
+    OQS->SetDecoAngle(3,6, std::acos(GetOscillationParameter(kTheta36)));
+    OQS->SetDecoAngle(3,7, std::acos(GetOscillationParameter(kTheta37)));
+    OQS->SetDecoAngle(3,8, std::acos(GetOscillationParameter(kTheta38)));
+    // i = 4
+    OQS->SetDecoAngle(4,5, std::acos(GetOscillationParameter(kTheta45)));
+    OQS->SetDecoAngle(4,6, std::acos(GetOscillationParameter(kTheta46)));
+    OQS->SetDecoAngle(4,7, std::acos(GetOscillationParameter(kTheta47)));
+    OQS->SetDecoAngle(4,8, std::acos(GetOscillationParameter(kTheta48)));
+    // i = 5
+    OQS->SetDecoAngle(5,6, std::acos(GetOscillationParameter(kTheta56)));
+    OQS->SetDecoAngle(5,7, std::acos(GetOscillationParameter(kTheta57)));
+    OQS->SetDecoAngle(5,8, std::acos(GetOscillationParameter(kTheta58)));
+    // i = 6
+    OQS->SetDecoAngle(6,7, std::acos(GetOscillationParameter(kTheta67)));
+    OQS->SetDecoAngle(6,8, std::acos(GetOscillationParameter(kTheta68)));
+    // i = 7
+    OQS->SetDecoAngle(7,8, std::acos(GetOscillationParameter(kTheta78)));
+    OQS->SetPower(GetOscillationParameter(kPower_OQS));
+  }
 }
 
 int OscProbCalcerOscProb::PMNS_StrToInt(const std::string& PMNSType) {
@@ -320,6 +371,7 @@ int OscProbCalcerOscProb::PMNS_StrToInt(const std::string& PMNSType) {
   if (PMNSType == "NUNM" || PMNSType == "nunm")          return kNUNM;
   if (PMNSType == "SNSI" || PMNSType == "snsi")          return kSNSI;
   if (PMNSType == "Iter" || PMNSType == "iter")          return kIter;
+  if (PMNSType == "OQS" || PMNSType == "oqs")            return kOQS;
 
   std::cerr << "Invalid PMNS matrix type provided:" << PMNSType << std::endl;
   throw std::runtime_error("Invalid setup");
@@ -348,7 +400,7 @@ void OscProbCalcerOscProb::SetOscParams() {
     OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp","alpha_2","alpha_3"};    
     break;
   case kDeco:
-    OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp","gamma_21","gamma_31","decoherence_angle","decoherence_index"};    
+    OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp","gamma_21","gamma_31","decoherence_angle","decoherence_index"};
     break;
   case kNSI:
     OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp","eps_ee", "eps_emu", "eps_etau", "eps_mumu", "eps_mutau", "eps_tautau", "delta_emu", "delta_etau", "delta_mutau", "elec_coup", "up_coup", "down_coup"};    
@@ -364,6 +416,20 @@ void OscProbCalcerOscProb::SetOscParams() {
     break;
   case kSNSI:
     OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp","delta_cp","eps_ee", "eps_emu", "eps_etau", "eps_mumu", "eps_mutau", "eps_tautau", "delta_emu", "delta_etau", "delta_mutau", "elec_coup", "up_coup", "down_coup","light_mass"};    
+    break;
+  case kOQS:
+    OscParNames = {"sin2_th12","sin2_th23","sin2_th13","dm2_12","dm2_23","delta_cp",
+                   // Decoherence magnitudes
+                   "a_1","a_2","a_3","a_4","a_5","a_6","a_7","a_8",
+                   // cosine angles between decoherence vectors
+                   "costheta_12","costheta_13","costheta_14","costheta_15","costheta_16","costheta_17","costheta_18",
+                   "costheta_23","costheta_24","costheta_25","costheta_26","costheta_27","costheta_28",
+                   "costheta_34","costheta_35","costheta_36","costheta_37","costheta_38",
+                   "costheta_45","costheta_46","costheta_47","costheta_48",
+                   "costheta_56","costheta_57","costheta_58",
+                   "costheta_67","costheta_68",
+                   "costheta_78",
+                   "decoherence_index"};
     break;
   default:
     std::cerr << "Invalid Oscillation Model type provided:" << fOscType << std::endl;

--- a/OscProbCalcer/OscProbCalcer_OscProb.h
+++ b/OscProbCalcer/OscProbCalcer_OscProb.h
@@ -236,6 +236,27 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
                      kNOscParams_LIV};
 
   /**
+  * @brief Definition of extra oscillation parameters for PMNS_OQS class (Open Quantum System decoherence model)
+  * kA_i     Magnitude of decoherence vector component a_i in the Gell-Mann basis, with i = 1,...,8. These correspond to
+  * kTheta_ij Cosine of the angle between decoherence vectors a_i and a_j,
+  * kPower_OQS power index of decoherence energy dependence
+  */
+  enum OscParams_OQS {
+    // Decoherence magnitudes (Gell-Mann basis)
+    kA1 = kNOscParams, kA2, kA3, kA4, kA5, kA6, kA7, kA8,
+    // Angles
+    kTheta12, kTheta13, kTheta14, kTheta15, kTheta16, kTheta17, kTheta18,
+    kTheta23, kTheta24, kTheta25, kTheta26, kTheta27, kTheta28,
+    kTheta34, kTheta35, kTheta36, kTheta37, kTheta38,
+    kTheta45, kTheta46, kTheta47, kTheta48,
+    kTheta56, kTheta57, kTheta58,
+    kTheta67, kTheta68,
+    kTheta78,
+    kPower_OQS,
+    kNOscParams_OQS
+  };
+
+  /**
    * @brief Define the neutrino and antineutrino values expected by this implementation
    */
   enum NuType{Nu=1,Nubar=-1};
@@ -245,7 +266,7 @@ class OscProbCalcerOscProb : public OscProbCalcerBase {
    * LIV and SNSI still to be implemented at some point
    */
   enum PMNSMatrix{kFast, kPMNSSterile1, kPMNSSterile2, kPMNSSterile3,
-                  kDecay, kDeco, kNSI, kSNSI, kIter, kNUNM, kLIV};
+                  kDecay, kDeco, kNSI, kSNSI, kIter, kNUNM, kLIV, kOQS};
 
   /**
    * @brief Define the type for the PMNS matrix


### PR DESCRIPTION
# Pull request description:
Open Quantum System has been recently added to OscProb
https://joaoabcoelho.github.io/OscProb/classOscProb_1_1PMNS__OQS.html

Based on this paper
https://arxiv.org/pdf/hep-ph/0208166

For validations I used values from:
https://github.com/joaoabcoelho/OscProb/blob/e9bf6f2e34e0d470c152422da30b43aaf901b7ce/test/Utils.h#L63-L76

## Examples:
When set all decoherence parameters to "default" I get same prob as for PMNS
[PMNS_Like.pdf](https://github.com/user-attachments/files/27633183/PMNS_Like.pdf)

Here I move only a3 param, responsible mostly for electron system, it mostly impact electron part. 
No longer agrees (good) with PMNS
[A3_Only.pdf](https://github.com/user-attachments/files/27633211/A3_Only.pdf)

Here I move only a8 param, responsible mostly for tau system, it mostly impacts tau part 
[A8_Only.pdf](https://github.com/user-attachments/files/27633217/A8_Only.pdf)
